### PR TITLE
ResultSet expects schema only when job is complete and supports requesting tokens when required

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,12 +2,14 @@
 use crate::error::BQError;
 use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
+use std::sync::Arc;
 use yup_oauth2::authenticator::Authenticator;
 use yup_oauth2::ServiceAccountKey;
 
 /// A service account authenticator.
+#[derive(Clone)]
 pub struct ServiceAccountAuthenticator {
-    auth: Authenticator<HttpsConnector<HttpConnector>>,
+    auth: Arc<Authenticator<HttpsConnector<HttpConnector>>>,
     scopes: Vec<String>,
 }
 
@@ -27,7 +29,7 @@ impl ServiceAccountAuthenticator {
         match auth {
             Err(err) => Err(BQError::InvalidServiceAccountAuthenticator(err)),
             Ok(auth) => Ok(ServiceAccountAuthenticator {
-                auth,
+                auth: Arc::new(auth),
                 scopes: scopes.iter().map(|scope| scope.to_string()).collect(),
             }),
         }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -2,6 +2,7 @@
 use log::info;
 use reqwest::Client;
 
+use crate::auth::ServiceAccountAuthenticator;
 use crate::error::BQError;
 use crate::model::dataset::Dataset;
 use crate::model::datasets::Datasets;
@@ -10,12 +11,12 @@ use crate::{process_response, urlencode};
 /// A dataset API handler.
 pub struct DatasetApi {
     client: Client,
-    access_token: String,
+    sa_auth: ServiceAccountAuthenticator,
 }
 
 impl DatasetApi {
-    pub(crate) fn new(client: Client, access_token: String) -> Self {
-        Self { client, access_token }
+    pub(crate) fn new(client: Client, sa_auth: ServiceAccountAuthenticator) -> Self {
+        Self { client, sa_auth }
     }
 
     /// Creates a new empty dataset.
@@ -45,10 +46,12 @@ impl DatasetApi {
             project_id = urlencode(project_id)
         );
 
+        let access_token = self.sa_auth.access_token().await?;
+
         let request = self
             .client
             .post(req_url.as_str())
-            .bearer_auth(&self.access_token)
+            .bearer_auth(access_token)
             .json(&dataset)
             .build()?;
 
@@ -88,7 +91,9 @@ impl DatasetApi {
             project_id = urlencode(project_id)
         );
 
-        let mut request = self.client.get(req_url).bearer_auth(&self.access_token);
+        let access_token = self.sa_auth.access_token().await?;
+
+        let mut request = self.client.get(req_url).bearer_auth(access_token);
 
         // process options
         if let Some(max_results) = options.max_results {
@@ -144,10 +149,12 @@ impl DatasetApi {
             dataset_id = urlencode(dataset_id)
         );
 
+        let access_token = self.sa_auth.access_token().await?;
+
         let request = self
             .client
             .delete(req_url)
-            .bearer_auth(&self.access_token)
+            .bearer_auth(access_token)
             .query(&[("deleteContents", delete_contents.to_string())])
             .build()?;
         let response = self.client.execute(request).await?;
@@ -228,7 +235,9 @@ impl DatasetApi {
             dataset_id = urlencode(dataset_id)
         );
 
-        let request = self.client.get(req_url).bearer_auth(&self.access_token).build()?;
+        let access_token = self.sa_auth.access_token().await?;
+
+        let request = self.client.get(req_url).bearer_auth(access_token).build()?;
         let response = self.client.execute(request).await?;
 
         process_response(response).await
@@ -246,10 +255,12 @@ impl DatasetApi {
             dataset_id = urlencode(dataset_id)
         );
 
+        let access_token = self.sa_auth.access_token().await?;
+
         let request = self
             .client
             .patch(req_url)
-            .bearer_auth(&self.access_token)
+            .bearer_auth(access_token)
             .json(&dataset)
             .build()?;
         let response = self.client.execute(request).await?;
@@ -268,10 +279,12 @@ impl DatasetApi {
             dataset_id = urlencode(dataset_id)
         );
 
+        let access_token = self.sa_auth.access_token().await?;
+
         let request = self
             .client
             .put(req_url)
-            .bearer_auth(&self.access_token)
+            .bearer_auth(access_token)
             .json(&dataset)
             .build()?;
         let response = self.client.execute(request).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,12 @@ impl Client {
             .await
             .expect("expecting a valid key");
 
-        let access_token = sa_auth.access_token().await.expect("expecting a valid token");
         let client = reqwest::Client::new();
         Self {
-            dataset_api: DatasetApi::new(client.clone(), access_token.clone()),
-            table_api: TableApi::new(client.clone(), access_token.clone()),
-            job_api: JobApi::new(client.clone(), access_token.clone()),
-            tabledata_api: TableDataApi::new(client, access_token),
+            dataset_api: DatasetApi::new(client.clone(), sa_auth.clone()),
+            table_api: TableApi::new(client.clone(), sa_auth.clone()),
+            job_api: JobApi::new(client.clone(), sa_auth.clone()),
+            tabledata_api: TableDataApi::new(client, sa_auth),
         }
     }
 
@@ -81,13 +80,12 @@ impl Client {
         };
         let sa_auth = ServiceAccountAuthenticator::from_service_account_key(sa_key, &scopes).await?;
 
-        let access_token = sa_auth.access_token().await?;
         let client = reqwest::Client::new();
         Ok(Self {
-            dataset_api: DatasetApi::new(client.clone(), access_token.clone()),
-            table_api: TableApi::new(client.clone(), access_token.clone()),
-            job_api: JobApi::new(client.clone(), access_token.clone()),
-            tabledata_api: TableDataApi::new(client, access_token),
+            dataset_api: DatasetApi::new(client.clone(), sa_auth.clone()),
+            table_api: TableApi::new(client.clone(), sa_auth.clone()),
+            job_api: JobApi::new(client.clone(), sa_auth.clone()),
+            tabledata_api: TableDataApi::new(client, sa_auth),
         })
     }
 

--- a/src/model/query_response.rs
+++ b/src/model/query_response.rs
@@ -73,22 +73,32 @@ pub struct ResultSet {
 
 impl ResultSet {
     pub fn new(query_response: QueryResponse) -> Self {
-        let row_count = query_response.rows.as_ref().map_or(0, |rows| rows.len()) as i64;
-        let table_schema = query_response.schema.as_ref().expect("Expecting a schema");
-        let table_fields = table_schema
-            .fields
-            .as_ref()
-            .expect("Expecting a non empty list of fields");
-        let fields: HashMap<String, usize> = table_fields
-            .iter()
-            .enumerate()
-            .map(|(pos, field)| (field.name.clone(), pos))
-            .collect();
-        Self {
-            cursor: -1,
-            row_count,
-            query_response,
-            fields,
+        if query_response.job_complete.unwrap_or(false) {
+            // rows and tables schema are only present for successfully completed jobs.
+            let row_count = query_response.rows.as_ref().map_or(0, Vec::len) as i64;
+            let table_schema = query_response.schema.as_ref().expect("Expecting a schema");
+            let table_fields = table_schema
+                .fields
+                .as_ref()
+                .expect("Expecting a non empty list of fields");
+            let fields: HashMap<String, usize> = table_fields
+                .iter()
+                .enumerate()
+                .map(|(pos, field)| (field.name.clone(), pos))
+                .collect();
+            Self {
+                cursor: -1,
+                row_count,
+                query_response,
+                fields,
+            }
+        } else {
+            Self {
+                cursor: -1,
+                row_count: 0,
+                query_response,
+                fields: HashMap::new(),
+            }
         }
     }
 


### PR DESCRIPTION
Just made a couple of changes. The first is for `ResultSet` to only expect the `rows` and `schema` fields when `jobComplete = true` as they are not present before this. 

The second is to update the job, table, tabledata and dataset APIs to have `ServiceAccountAuthenticator` fields from which they request tokens when one of their methods is called. This is to utilise `yup_oauth2`'s caching and auto-refreshing of tokens that expire.