### PR TITLE
Properly parse big integer

### DIFF
--- a/src/model/query_response.rs
+++ b/src/model/query_response.rs
@@ -139,17 +139,14 @@ impl ResultSet {
             None => Ok(None),
             Some(json_value) => match json_value {
                 serde_json::Value::Number(value) => Ok(value.as_i64()),
-                serde_json::Value::String(value) => {
-                    let value: Result<i64, _> = value.parse();
-                    match &value {
-                        Err(_) => Err(BQError::InvalidColumnType {
-                            col_index,
-                            col_type: ResultSet::json_type(json_value),
-                            type_requested: "I64".into(),
-                        }),
-                        Ok(value) => Ok(Some(*value)),
-                    }
-                }
+                serde_json::Value::String(value) => match value.parse::<f64>() {
+                    Ok(v) => Ok(Some(v as i64)),
+                    Err(_) => Err(BQError::InvalidColumnType {
+                        col_index,
+                        col_type: ResultSet::json_type(json_value),
+                        type_requested: "I64".into(),
+                    }),
+                },
                 _ => Err(BQError::InvalidColumnType {
                     col_index,
                     col_type: ResultSet::json_type(json_value),

--- a/src/model/query_response.rs
+++ b/src/model/query_response.rs
@@ -139,9 +139,10 @@ impl ResultSet {
             None => Ok(None),
             Some(json_value) => match json_value {
                 serde_json::Value::Number(value) => Ok(value.as_i64()),
-                serde_json::Value::String(value) => match value.parse::<f64>() {
-                    Ok(v) => Ok(Some(v as i64)),
-                    Err(_) => Err(BQError::InvalidColumnType {
+                serde_json::Value::String(value) => match (value.parse::<i64>(), value.parse::<f64>()) {
+                    (Ok(v), _) => Ok(Some(v)),
+                    (Err(_), Ok(v)) => Ok(Some(v as i64)),
+                    _ => Err(BQError::InvalidColumnType {
                         col_index,
                         col_type: ResultSet::json_type(json_value),
                         type_requested: "I64".into(),


### PR DESCRIPTION
Hi !
I encountered an error in parsing big integer.

For example, `123.45E4` is integer and this should be parsed as `1234500` but this fails.
Rust cannot parse `123.45E4` as integer but can parse as float.

So with this change, we at first accept data as float and then cast it as integer.

![スクリーンショット 2021-08-23 15 28 21](https://user-images.githubusercontent.com/27967726/130400735-0da0b69e-69b5-48f8-8a6e-9a19ea879d7a.png)
