### PR TITLE
Fix struct for workload identity

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -67,8 +67,8 @@ pub(crate) async fn service_account_authenticator(
 #[derive(Deserialize)]
 pub struct WorkloadIdentityAccessToken {
     pub access_token: String,
-    _expires_in: i32,
-    _token_type: String,
+    expires_in: i32,
+    token_type: String,
 }
 
 pub(crate) async fn get_access_token_with_workload_identity() -> Result<WorkloadIdentityAccessToken, BQError> {


### PR DESCRIPTION
When I use new version of this, errors has happened because of the difference of keys.
Serialize didn't work fine.

I fixed this.