### PR TITLE
Update yup-oauth2 dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcp-bigquery-client"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Laurent Querel <laurent.querel@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,17 +16,17 @@ keywords = ["gcp", "bigquery", "google-cloud"]
 categories = ["database"]
 
 [dependencies]
-yup-oauth2 = "5.0.3"
-hyper = "0.14.4"
+yup-oauth2 = "6.0.0"
+hyper = "0.14.13"
 hyper-rustls = "0.22.1"
-thiserror = "1.0.23"
-tokio = { version = "1.2.0", features = ["full"] }
-reqwest = { version = "0.11.0", features = ["json"] }
-url = "2.2.0"
-serde = "1.0.123"
-serde_json = "1.0.63"
-log = "0.4"
+thiserror = "1.0.29"
+tokio = { version = "1.12.0", features = ["full"] }
+reqwest = { version = "0.11.4", features = ["json"] }
+url = "2.2.2"
+serde = "1.0.130"
+serde_json = "1.0.68"
+log = "0.4.14"
 chrono = "0.4.19"
 
 [dev-dependencies]
-tokio-test = "0.4.0"
+tokio-test = "0.4.2"


### PR DESCRIPTION
Annoyingly this is a breaking change as the version of yup-oauth2
is exposed in the public `Client::from_service_account_key`
function.

I also took the liberty of updating the minor version numbers of
other dependencies in `Cargo.toml`. Let me know if you want
to revert this.