### PR TITLE
Update chrono and use serde features that fix build errors 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ url = "2"
 serde = "1"
 serde_json = "1"
 log = "0.4"
-chrono = "0.4"
+chrono = { version = "0.4.19", features = ["serde"] }
 
 [dev-dependencies]
 tokio-test = "0.4"


### PR DESCRIPTION
Fix build errors caused by `RowAccessPolicy`  where `DateTime` from chronos does not implement Serialize.

![image](https://user-images.githubusercontent.com/23079317/161424172-a9c38a06-e644-4524-93ab-6389a58bbbcb.png)
