### PR TITLE
skip schema field when the schema has no fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bq_load_job = ["cloud-storage"]
 [dependencies]
 yup-oauth2 = "6.5.1"
 hyper = {version="0.14", features = ["http1"]}
-hyper-rustls = {version="0.22", features = ["native-tokio"]}
+hyper-rustls = {version="0.23.0", features = ["native-tokio"]}
 thiserror = "1"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "sync", "macros"] }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -77,6 +77,7 @@ pub struct Table {
     /// [Optional] If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub require_partition_filter: Option<bool>,
+    #[serde(skip_serializing_if = "TableSchema::is_none")]
     pub schema: TableSchema,
     /// [Output-only] A URL that can be used to access this resource again.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/model/table_schema.rs
+++ b/src/model/table_schema.rs
@@ -21,4 +21,8 @@ impl TableSchema {
     pub fn field_count(&self) -> usize {
         self.fields.as_ref().map_or(0, |fields| fields.len())
     }
+
+    pub fn is_none(&self) -> bool {
+        self.fields.is_none()
+    }
 }


### PR DESCRIPTION
## Context

With version 0.12 of the library I get a 400 Error `Schema field shouldn't be used as input with a view` when I try to create a view.

In order to make it possible to create views using the library we need to make sure that there is a way to stop the library sending the schema field.  The obvious way to do this would be to make the schema field an `Option<TableSchema>` but this has comparability implications for existing code.

The alternative approach that I went with is to add a `is_none` method to `TableSchema` so that we can skip serialisation for this field if its inner Option is none.  I have tested this and it works as expected.

## Changes

* Fix a small diamond dependency problem related to `hyper-rustls`
* Configured serde to skip the `schema` field if its inner `fields` variable is `None`

## Testing

* I have tested that it is still possible to create tables
* I have also tested that it is now possible to create views using the library

