### PR TITLE
Add `query_all`, a paginated query method

### DIFF
--- a/examples/pagination.rs
+++ b/examples/pagination.rs
@@ -1,0 +1,21 @@
+use gcp_bigquery_client::env_vars;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (ref project_id, ref dataset_id, ref table_id, ref gcp_sa_key) = env_vars();
+    let client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await;
+
+    let result_set = client
+        .job()
+        .query_all(
+            project_id,
+            format!("SELECT * FROM `{project_id}.{dataset_id}.{table_id}`"),
+            None,
+            Some(1),
+        )
+        .await?;
+
+    println!("{}", result_set.rows().len());
+
+    Ok(())
+}

--- a/examples/pagination.rs
+++ b/examples/pagination.rs
@@ -1,4 +1,4 @@
-use gcp_bigquery_client::env_vars;
+use gcp_bigquery_client::{env_vars, model::job_configuration_query::JobConfigurationQuery};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -9,8 +9,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .job()
         .query_all(
             project_id,
-            format!("SELECT * FROM `{project_id}.{dataset_id}.{table_id}`"),
-            None,
+            JobConfigurationQuery {
+                query: format!("SELECT * FROM `{project_id}.{dataset_id}.{table_id}`"),
+                query_parameters: None,
+                use_legacy_sql: Some(false),
+                ..Default::default()
+            },
             Some(1),
         )
         .await?;

--- a/src/job.rs
+++ b/src/job.rs
@@ -57,6 +57,7 @@ impl JobApi {
         project_id: &str,
         query: String,
         query_parameters: Option<Vec<QueryParameter>>,
+        max_results: Option<i32>,
     ) -> Result<PaginatedResultSet, BQError> {
         let job = Job {
             configuration: Some(JobConfiguration {
@@ -84,6 +85,7 @@ impl JobApi {
                         job_id,
                         GetQueryResultsParameters {
                             page_token,
+                            max_results,
                             ..Default::default()
                         },
                     )

--- a/src/job.rs
+++ b/src/job.rs
@@ -10,7 +10,6 @@ use crate::model::job_cancel_response::JobCancelResponse;
 use crate::model::job_configuration::JobConfiguration;
 use crate::model::job_configuration_query::JobConfigurationQuery;
 use crate::model::job_list::JobList;
-use crate::model::query_parameter::QueryParameter;
 use crate::model::query_request::QueryRequest;
 use crate::model::query_response::{QueryResponse, ResultSet};
 use crate::{process_response, urlencode};
@@ -55,19 +54,13 @@ impl JobApi {
     pub async fn query_all(
         &self,
         project_id: &str,
-        query: String,
-        query_parameters: Option<Vec<QueryParameter>>,
+        query: JobConfigurationQuery,
         max_results: Option<i32>,
     ) -> Result<PaginatedResultSet, BQError> {
         let job = Job {
             configuration: Some(JobConfiguration {
                 dry_run: Some(false),
-                query: Some(JobConfigurationQuery {
-                    query,
-                    query_parameters,
-                    use_legacy_sql: Some(false),
-                    ..Default::default()
-                }),
+                query: Some(query),
                 ..Default::default()
             }),
             ..Default::default()

--- a/src/job.rs
+++ b/src/job.rs
@@ -51,11 +51,16 @@ impl JobApi {
         Ok(ResultSet::new(query_response))
     }
 
+    /// Runs a BigQuery SQL query, paginating through all the results synchronously.
+    /// # Arguments
+    /// * `project_id`- Project ID of the query request.
+    /// * `query` - The initial query configuration that is submitted when the job is inserted.
+    /// * `page_size` - The size of each page fetched. By default, this is set to `None`, and the limit is 10 MB of rows instead.
     pub async fn query_all(
         &self,
         project_id: &str,
         query: JobConfigurationQuery,
-        max_results: Option<i32>,
+        page_size: Option<i32>,
     ) -> Result<PaginatedResultSet, BQError> {
         let job = Job {
             configuration: Some(JobConfiguration {
@@ -78,7 +83,7 @@ impl JobApi {
                         job_id,
                         GetQueryResultsParameters {
                             page_token,
-                            max_results,
+                            max_results: page_size,
                             ..Default::default()
                         },
                     )

--- a/src/job.rs
+++ b/src/job.rs
@@ -55,7 +55,8 @@ impl JobApi {
     /// # Arguments
     /// * `project_id`- Project ID of the query request.
     /// * `query` - The initial query configuration that is submitted when the job is inserted.
-    /// * `page_size` - The size of each page fetched. By default, this is set to `None`, and the limit is 10 MB of rows instead.
+    /// * `page_size` - The size of each page fetched. By default, this is set to `None`, and the limit is 10 MB of
+    /// rows instead.
     pub async fn query_all(
         &self,
         project_id: &str,

--- a/src/model/get_query_results_response.rs
+++ b/src/model/get_query_results_response.rs
@@ -32,3 +32,20 @@ pub struct GetQueryResultsResponse {
     /// The total number of rows in the complete query result set, which can be more than the number of rows in this single page of results. Present only when the query completes successfully.
     pub total_rows: Option<String>,
 }
+
+#[derive(Debug, Default)]
+pub struct PaginatedResultSet {
+    rows: Vec<TableRow>,
+}
+
+impl PaginatedResultSet {
+    pub(crate) fn append(&mut self, rows: Option<Vec<TableRow>>) {
+        if let Some(mut rows) = rows {
+            self.rows.append(&mut rows);
+        }
+    }
+
+    pub fn rows(&self) -> &[TableRow] {
+        self.rows.as_ref()
+    }
+}


### PR DESCRIPTION
Hi,

We run queries that exceed the 10 MB response limit.
After some work digging through the API, we figured out how to do the pagination, but wanted to contribute back to the project by adding a method to the `JobApi` that paginates by default.

It's not a complete solution by any means, but it works for us and we're happy to modify it to match the vision of this project.