### PR TITLE
feat(job): Make query pagination an async stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ hyper = {version="0.14", features = ["http1"]}
 hyper-rustls = {version="0.23.0", features = ["native-tokio"]}
 thiserror = "1"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "sync", "macros"] }
+tokio-stream = "0.1"
+async-stream = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 url = "2"
 serde = "1"

--- a/examples/pagination.rs
+++ b/examples/pagination.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     tokio::pin!(result_set);
-    
+
     while let Some(page) = result_set.next().await {
         match page {
             Ok(rows) => println!("Page rows: {}", rows.len()),

--- a/examples/pagination.rs
+++ b/examples/pagination.rs
@@ -1,25 +1,30 @@
 use gcp_bigquery_client::{env_vars, model::job_configuration_query::JobConfigurationQuery};
+use tokio_stream::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (ref project_id, ref dataset_id, ref table_id, ref gcp_sa_key) = env_vars();
     let client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await;
 
-    let result_set = client
-        .job()
-        .query_all(
-            project_id,
-            JobConfigurationQuery {
-                query: format!("SELECT * FROM `{project_id}.{dataset_id}.{table_id}`"),
-                query_parameters: None,
-                use_legacy_sql: Some(false),
-                ..Default::default()
-            },
-            Some(1),
-        )
-        .await?;
+    let result_set = client.job().query_all(
+        project_id,
+        JobConfigurationQuery {
+            query: format!("SELECT * FROM `{project_id}.{dataset_id}.{table_id}`"),
+            query_parameters: None,
+            use_legacy_sql: Some(false),
+            ..Default::default()
+        },
+        Some(1),
+    );
 
-    println!("{}", result_set.rows().len());
+    tokio::pin!(result_set);
+    
+    while let Some(page) = result_set.next().await {
+        match page {
+            Ok(rows) => println!("Page rows: {}", rows.len()),
+            Err(e) => println!("BigQuery error: {e:?}"),
+        }
+    }
 
     Ok(())
 }

--- a/src/model/get_query_results_response.rs
+++ b/src/model/get_query_results_response.rs
@@ -32,20 +32,3 @@ pub struct GetQueryResultsResponse {
     /// The total number of rows in the complete query result set, which can be more than the number of rows in this single page of results. Present only when the query completes successfully.
     pub total_rows: Option<String>,
 }
-
-#[derive(Debug, Default)]
-pub struct PaginatedResultSet {
-    rows: Vec<TableRow>,
-}
-
-impl PaginatedResultSet {
-    pub(crate) fn append(&mut self, rows: Option<Vec<TableRow>>) {
-        if let Some(mut rows) = rows {
-            self.rows.append(&mut rows);
-        }
-    }
-
-    pub fn rows(&self) -> &[TableRow] {
-        self.rows.as_ref()
-    }
-}


### PR DESCRIPTION
I've thought a bit about how we can make the pagination more flexible for diverse usecases, and I'm sure people want to handle possible errors differently, so I suggest we go with something á la the following to make that possible:

The pagination becomes an asynchronous iterator over `Result<Vec<TableRow>, BQError>`. People are then able to stream through very large results without exhausting memory, and can use `collect` and `flatten` to imitate the previous implementation.