### PR TITLE
return Result for Client::from_service_account_key_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ rows are based on a regular Rust struct implementing the trait Serialize.
 
 ```rust
     // Init BigQuery client
-    let client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await;
+    let client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await?;
 
     // Delete the dataset if needed
     let result = client.dataset().delete(project_id, dataset_id, true).await;

--- a/examples/bq_load_job.rs
+++ b/examples/bq_load_job.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Store data on GCS
         let source_uri = store_and_get_gcs_uri(GCS_BUCKET_NAME, data, &tmp_file_name).await?;
 
-        let client = Client::from_service_account_key_file(&gcp_sa_key).await;
+        let client = Client::from_service_account_key_file(&gcp_sa_key).await?;
 
         // Create BQ load job to create/update the test with the content of the json data file
         // Pre-requisite: test_batch_load dataset already created

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), BQError> {
     let (ref project_id, ref dataset_id, ref table_id, ref gcp_sa_key) = env_vars();
 
     // Init BigQuery client
-    let client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await;
+    let client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await?;
 
     // Delete the dataset if needed
     let result = client.dataset().delete(project_id, dataset_id, true).await;

--- a/examples/pagination.rs
+++ b/examples/pagination.rs
@@ -4,7 +4,7 @@ use tokio_stream::StreamExt;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (ref project_id, ref dataset_id, ref table_id, ref gcp_sa_key) = env_vars();
-    let client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await;
+    let client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await?;
 
     let result_set = client.job().query_all(
         project_id,

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -46,15 +46,13 @@ impl ClientBuilder {
         Ok(client)
     }
 
-    pub async fn build_from_service_account_key_file(&self, sa_key_file: &str) -> Client {
+    pub async fn build_from_service_account_key_file(&self, sa_key_file: &str) -> Result<Client, BQError> {
         let scopes = vec![self.auth_base_url.as_str()];
-        let sa_auth = service_account_authenticator(scopes, sa_key_file)
-            .await
-            .expect("expecting a valid key");
+        let sa_auth = service_account_authenticator(scopes, sa_key_file).await?;
 
         let mut client = Client::from_authenticator(sa_auth);
         client.v2_base_url(self.v2_base_url.clone());
-        client
+        Ok(client)
     }
 
     pub async fn build_with_workload_identity(&self, readonly: bool) -> Result<Client, BQError> {

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -49,7 +49,7 @@ impl DatasetApi {
     /// let (ref project_id, ref dataset_id, ref _table_id, ref sa_key) = env_vars();
     /// let dataset_id = &format!("{}_dataset", dataset_id);
     ///
-    /// let client = Client::from_service_account_key_file(sa_key).await;
+    /// let client = Client::from_service_account_key_file(sa_key).await?;
     ///
     /// # client.dataset().delete_if_exists(project_id, dataset_id, true);
     /// client.dataset().create(Dataset::new(project_id, dataset_id)).await?;
@@ -93,7 +93,7 @@ impl DatasetApi {
     /// let (ref project_id, ref dataset_id, ref _table_id, ref sa_key) = env_vars();
     /// let dataset_id = &format!("{}_dataset", dataset_id);
     ///
-    /// let client = Client::from_service_account_key_file(sa_key).await;
+    /// let client = Client::from_service_account_key_file(sa_key).await?;
     ///
     /// let datasets = client.dataset().list(project_id, ListOptions::default().all(true)).await?;
     /// for dataset in datasets.datasets.iter() {
@@ -152,7 +152,7 @@ impl DatasetApi {
     /// let (ref project_id, ref dataset_id, ref _table_id, ref sa_key) = env_vars();
     /// let dataset_id = &format!("{}_dataset", dataset_id);
     ///
-    /// let client = Client::from_service_account_key_file(sa_key).await;
+    /// let client = Client::from_service_account_key_file(sa_key).await?;
     ///
     /// # client.dataset().delete_if_exists(project_id, dataset_id, true);
     /// client.dataset().create(Dataset::new(project_id, dataset_id)).await?;
@@ -207,7 +207,7 @@ impl DatasetApi {
     /// let (ref project_id, ref dataset_id, ref _table_id, ref sa_key) = env_vars();
     /// let dataset_id = &format!("{}_dataset", dataset_id);
     ///
-    /// let client = Client::from_service_account_key_file(sa_key).await;
+    /// let client = Client::from_service_account_key_file(sa_key).await?;
     ///
     /// client.dataset().delete_if_exists(project_id, dataset_id, true);
     /// # Ok(())
@@ -245,7 +245,7 @@ impl DatasetApi {
     /// let (ref project_id, ref dataset_id, ref _table_id, ref sa_key) = env_vars();
     /// let dataset_id = &format!("{}_dataset", dataset_id);
     ///
-    /// let client = Client::from_service_account_key_file(sa_key).await;
+    /// let client = Client::from_service_account_key_file(sa_key).await?;
     ///
     /// # client.dataset().delete_if_exists(project_id, dataset_id, true);
     /// client.dataset().create(Dataset::new(project_id, dataset_id)).await?;
@@ -428,7 +428,7 @@ mod test {
         let (ref project_id, ref dataset_id, ref _table_id, ref sa_key) = env_vars();
         let dataset_id = &format!("{}_dataset", dataset_id);
 
-        let client = Client::from_service_account_key_file(sa_key).await;
+        let client = Client::from_service_account_key_file(sa_key).await?;
 
         // Delete the dataset if needed
         let result = client.dataset().delete(project_id, dataset_id, true).await;
@@ -485,7 +485,7 @@ mod test {
         let (ref project_id, ref _dataset_id, ref _table_id, ref sa_key) = env_vars();
         //let dataset_id = &format!("{}_dataset", dataset_id);
 
-        let client = Client::from_service_account_key_file(sa_key).await;
+        let client = Client::from_service_account_key_file(sa_key).await?;
 
         let result = client
             .dataset()

--- a/src/job.rs
+++ b/src/job.rs
@@ -308,7 +308,7 @@ mod test {
         let (ref project_id, ref dataset_id, ref table_id, ref sa_key) = env_vars();
         let dataset_id = &format!("{}_job", dataset_id);
 
-        let client = Client::from_service_account_key_file(sa_key).await;
+        let client = Client::from_service_account_key_file(sa_key).await?;
 
         client.table().delete_if_exists(project_id, dataset_id, table_id).await;
         client.dataset().delete_if_exists(project_id, dataset_id, true).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ impl Client {
     /// Constructs a new BigQuery client.
     /// # Argument
     /// * `sa_key_file` - A GCP Service Account Key file.
-    pub async fn from_service_account_key_file(sa_key_file: &str) -> Self {
+    pub async fn from_service_account_key_file(sa_key_file: &str) -> Result<Self, BQError> {
         ClientBuilder::new()
             .build_from_service_account_key_file(sa_key_file)
             .await

--- a/src/table.rs
+++ b/src/table.rs
@@ -380,7 +380,7 @@ mod test {
         let (ref project_id, ref dataset_id, ref table_id, ref sa_key) = env_vars();
         let dataset_id = &format!("{}_table", dataset_id);
 
-        let client = Client::from_service_account_key_file(sa_key).await;
+        let client = Client::from_service_account_key_file(sa_key).await?;
 
         // Delete the dataset if needed
         client.dataset().delete_if_exists(project_id, dataset_id, true).await;

--- a/src/tabledata.rs
+++ b/src/tabledata.rs
@@ -148,7 +148,7 @@ mod test {
         let (ref project_id, ref dataset_id, ref table_id, ref sa_key) = env_vars();
         let dataset_id = &format!("{}_tabledata", dataset_id);
 
-        let client = Client::from_service_account_key_file(sa_key).await;
+        let client = Client::from_service_account_key_file(sa_key).await?;
 
         client.table().delete_if_exists(project_id, dataset_id, table_id).await;
         client.dataset().delete_if_exists(project_id, dataset_id, true).await;


### PR DESCRIPTION
This PR is to make `Client::from_service_account_key_file` return `Result`, same as `Client::from_service_account_key`. It will close #39.