### PR TITLE
Enable `location` when `calling query_all()` job

### DIFF
--- a/examples/pagination.rs
+++ b/examples/pagination.rs
@@ -4,10 +4,12 @@ use tokio_stream::StreamExt;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (ref project_id, ref dataset_id, ref table_id, ref gcp_sa_key) = env_vars();
-    let client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await?;
+    let location = "us";
+    let client   = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await?;
 
     let result_set = client.job().query_all(
         project_id,
+        location,
         JobConfigurationQuery {
             query: format!("SELECT * FROM `{project_id}.{dataset_id}.{table_id}`"),
             query_parameters: None,


### PR DESCRIPTION
Fixes #48

Turned out that `location` field is part of `JobReference` struct and that one was [hard-coded to default when calling query_all() ](https://github.com/lquerel/gcp-bigquery-client/blob/main/src/job.rs#L90) instead of being exposed to the user

I was thinking between changing `query_all` signature to either
```
pub fn query_all<'a> (
   &'a self,
   project_id: &'a str,
   location:   &'a str,
   query: JobConfigurationQuery,
   page_size: Option<i32>,
)
```
or
```
pub fn query_all<'a> (
   &'a self,
   project_id: &'a str,
   job_reference: Option<JobReference>,
   query: JobConfigurationQuery,
   page_size: Option<i32>,
)
```
and it seems like first option makes more sense

I'm eager to get this one merged asap, so do let me know if some changes to PR required before that