### PR TITLE
Fix `Rows are not present` when job not completed yet.

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -170,7 +170,7 @@ impl JobApi {
 
                         // Waiting for completed the job.
                         if !qr.job_complete.unwrap_or(false) {
-                            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
                             continue;
                         }

--- a/src/job.rs
+++ b/src/job.rs
@@ -160,13 +160,21 @@ impl JobApi {
                             project_id,
                             job_id,
                             GetQueryResultsParameters {
-                                page_token,
+                                page_token: page_token.clone(),
                                 max_results: page_size,
                                 location:    Some(location.to_string()),
                                 ..Default::default()
                             },
                         )
                         .await?;
+
+                        // Waiting for completed the job.
+                        if !qr.job_complete.unwrap_or(false) {
+                            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+                            continue;
+                        }
+
 
                     // Rows is present when the query finishes successfully.
                     yield Ok(qr.rows.expect("Rows are not present"));

--- a/src/job.rs
+++ b/src/job.rs
@@ -177,7 +177,8 @@ impl JobApi {
 
 
                     // Rows is present when the query finishes successfully.
-                    yield Ok(qr.rows.expect("Rows are not present"));
+                    // Rows be empty when query result is empty.
+                    yield Ok(qr.rows.unwrap_or_else(Vec::new));
 
                     page_token = match qr.page_token {
                         None => break,


### PR DESCRIPTION
I seen panic with `Rows are not present` when execute large query.
