### PR TITLE
Add get_serde for types that implement Deserialize

### DIFF
--- a/src/model/query_response.rs
+++ b/src/model/query_response.rs
@@ -167,6 +167,33 @@ impl ResultSet {
         }
     }
 
+    pub fn get_serde<T>(&self, col_index: usize) -> Result<Option<T>, BQError> where T: serde::de::DeserializeOwned {
+        let json_value = self.get_json_value(col_index)?;
+        match json_value {
+            None => Ok(None),
+            Some(json_value) => match serde_json::from_value::<T>(json_value.clone()) {
+                Ok(value) => Ok(Some(value)),
+                Err(_) => {
+                    Err(BQError::InvalidColumnType {
+                    col_index,
+                    col_type: ResultSet::json_type(&json_value),
+                    type_requested: std::any::type_name::<T>().to_string(),
+                })
+                }
+            },
+        }
+    }
+
+    pub fn get_serde_by_name<T>(&self, col_name: &str) -> Result<Option<T>, BQError> where T: serde::de::DeserializeOwned {
+        let col_index = self.fields.get(col_name);
+        match col_index {
+            None => Err(BQError::InvalidColumnName {
+                col_name: col_name.into(),
+            }),
+            Some(col_index) => self.get_serde(*col_index),
+        }
+    }
+
     pub fn get_f64(&self, col_index: usize) -> Result<Option<f64>, BQError> {
         let json_value = self.get_json_value(col_index)?;
         match &json_value {


### PR DESCRIPTION
This PR adds a method to allow users to get a column by index or by name for any type that implements `serde::de::DeserializeOwned`. This is helpful as it opens up many new types to the crate.

For example:

If a user whats to get dates with chrono they can use:

```rust
result.get_serde::<NaiveDate>(col_index);
```
When the type is not able to be parsed errors show the `type_resquested` as follows:

```
Err(InvalidColumnType { col_index: 1, col_type: "String", type_requested: "bigdecimal::BigDecimal" })
```
