### PR TITLE
Adding Json to FieldType and missing helper methods

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -403,6 +403,9 @@ mod test {
     use crate::model::dataset::Dataset;
     use crate::model::job_configuration_query::JobConfigurationQuery;
     use crate::model::job_reference::JobReference;
+    use crate::model::query_parameter::QueryParameter;
+    use crate::model::query_parameter_type::QueryParameterType;
+    use crate::model::query_parameter_value::QueryParameterValue;
     use crate::model::query_request::QueryRequest;
     use crate::model::query_response::{QueryResponse, ResultSet};
     use crate::model::table::Table;
@@ -418,6 +421,7 @@ mod test {
         bool_value: bool,
         string_value: String,
         record_value: FirstRecordLevel,
+        json_value: String,
     }
 
     #[derive(Serialize)]
@@ -471,6 +475,7 @@ mod test {
                         ),
                     ],
                 ),
+                TableFieldSchema::json("json_value"),
             ]),
         );
 
@@ -494,6 +499,7 @@ mod test {
                         string_value: "leaf".to_string(),
                     },
                 },
+                json_value: "{\"a\":2,\"b\":\"hello\"}".into(),
             },
         )?;
         insert_request.add_row(
@@ -511,6 +517,7 @@ mod test {
                         string_value: "leaf".to_string(),
                     },
                 },
+                json_value: "{\"a\":1,\"b\":\"goodbye\",\"c\":3}".into(),
             },
         )?;
         insert_request.add_row(
@@ -528,6 +535,7 @@ mod test {
                         string_value: "leaf".to_string(),
                     },
                 },
+                json_value: "{\"b\":\"world\",\"c\":2}".into(),
             },
         )?;
         insert_request.add_row(
@@ -545,6 +553,7 @@ mod test {
                         string_value: "leaf".to_string(),
                     },
                 },
+                json_value: "{\"a\":3,\"c\":1}".into(),
             },
         )?;
 
@@ -663,6 +672,31 @@ mod test {
         assert!(query_all_results_with_job_reference.is_ok());
         assert_eq!(query_all_results_with_job_reference.unwrap().len(), n_rows);
 
+        // Query all with json parameter
+        let query_all_results_with_parameter: Result<Vec<_>, _> = client
+            .job()
+            .query_all(
+                project_id,
+                JobConfigurationQuery {
+                    query: format!("SELECT int_value, json_value.a, json_value.b FROM `{project_id}.{dataset_id}.{table_id}` where CAST(JSON_VALUE(json_value,'$.a') as int) >= @int_value"),
+                    query_parameters: Some(vec![QueryParameter{ 
+                        name: Some("int_value".to_string()), 
+                        parameter_type: Some(QueryParameterType{ array_type: None, struct_types: None, r#type: "INTEGER".to_string() }), 
+                        parameter_value: Some(QueryParameterValue{ array_values: None, struct_values: None, value: Some("2".to_string()) }),
+                    }]),
+                    use_legacy_sql: Some(false),
+                    ..Default::default()
+                },
+                Some(2),
+            )
+            .collect::<Result<Vec<_>, _>>()
+            .await
+            .map(|vec_of_vecs| vec_of_vecs.into_iter().flatten().collect());
+
+        assert!(query_all_results_with_parameter.is_ok());
+        assert_eq!(query_all_results_with_parameter.unwrap().len(), 2);
+
+        // Delete table
         client.table().delete(project_id, dataset_id, table_id).await?;
 
         // Delete dataset

--- a/src/model/field_type.rs
+++ b/src/model/field_type.rs
@@ -20,4 +20,5 @@ pub enum FieldType {
     Record, // where RECORD indicates that the field contains a nested schema
     Struct, // same as RECORD
     Geography,
+    Json,
 }

--- a/src/model/field_type.rs
+++ b/src/model/field_type.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -21,4 +21,12 @@ pub enum FieldType {
     Struct, // same as RECORD
     Geography,
     Json,
+}
+
+pub fn serialize_json_as_string<S>(json: &serde_json::value::Value, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let string = serde_json::to_string(json).unwrap();
+    s.serialize_str(&string)
 }

--- a/src/model/field_type.rs
+++ b/src/model/field_type.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer, ser::Error};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -27,6 +27,6 @@ pub fn serialize_json_as_string<S>(json: &serde_json::value::Value, s: S) -> Res
 where
     S: Serializer,
 {
-    let string = serde_json::to_string(json).unwrap();
+    let string = serde_json::to_string(json).map_err(Error::custom)?;
     s.serialize_str(&string)
 }

--- a/src/model/field_type.rs
+++ b/src/model/field_type.rs
@@ -27,6 +27,6 @@ pub fn serialize_json_as_string<S>(json: &serde_json::value::Value, s: S) -> Res
 where
     S: Serializer,
 {
-    let string = serde_json::to_string(json).map_err(Error::custom)?;
+    let string = serde_json::to_string(json).map_err(S::Error::custom)?;
     s.serialize_str(&string)
 }

--- a/src/model/table_field_schema.rs
+++ b/src/model/table_field_schema.rs
@@ -181,4 +181,28 @@ impl TableFieldSchema {
             r#type: FieldType::Datetime,
         }
     }
+
+    pub fn geography(field_name: &str) -> Self {
+        Self {
+            categories: None,
+            description: None,
+            fields: None,
+            mode: None,
+            name: field_name.into(),
+            policy_tags: None,
+            r#type: FieldType::Geography,
+        }
+    }
+
+    pub fn json(field_name: &str) -> Self {
+        Self {
+            categories: None,
+            description: None,
+            fields: None,
+            mode: None,
+            name: field_name.into(),
+            policy_tags: None,
+            r#type: FieldType::Json,
+        }
+    }
 }


### PR DESCRIPTION
Adding Json as a field type

Complete list is here: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TableFieldSchema

Json seems to be the only one that was missing in the enum, but Json & Geography were both missing in the helper functions.

This should fix https://github.com/lquerel/gcp-bigquery-client/issues/56