### PR TITLE
Feature/paginate through all jobs list

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -14,6 +14,7 @@ use crate::model::job_cancel_response::JobCancelResponse;
 use crate::model::job_configuration::JobConfiguration;
 use crate::model::job_configuration_query::JobConfigurationQuery;
 use crate::model::job_list::JobList;
+use crate::model::job_list_parameters::JobListParameters;
 use crate::model::job_reference::JobReference;
 use crate::model::query_request::QueryRequest;
 use crate::model::query_response::{QueryResponse, ResultSet};
@@ -292,6 +293,49 @@ impl JobApi {
         let resp = self.client.execute(request).await?;
 
         process_response(resp).await
+    }
+
+    /// Lists all jobs that you started in the specified project paginating through all the results synchronously.
+    /// Job information is available for a six month period after creation.
+    /// The job list is sorted in reverse chronological order, by job creation time. Requires the Can
+    /// View project role, or the Is Owner project role if you set the allUsers property.
+    /// # Arguments
+    /// * `project_id` - Project ID of the jobs to list.
+    /// * `parameters` - The query parameters for jobs.list.
+    pub fn get_job_list<'a>(
+        &'a self,
+        project_id: &'a str,
+        parameters: Option<JobListParameters>,
+    ) -> impl Stream<Item = Result<JobList, BQError>> + 'a {
+        stream! {
+            let req_url = format!(
+                "{base_url}/projects/{project_id}/jobs",
+                base_url = self.base_url,
+                project_id = urlencode(project_id),
+                );
+            let mut params = parameters.unwrap_or_default();
+            let mut page_token: Option<String> = None;
+            loop {
+                let mut request_builder = self.client.get(req_url.as_str());
+
+                params.page_token = page_token;
+                request_builder = request_builder.query(&params);
+
+                let access_token = self.auth.access_token().await?;
+                let request = request_builder.bearer_auth(access_token).build()?;
+
+                let resp = self.client.execute(request).await?;
+
+                let process_resp: Result<JobList, BQError> = process_response(resp).await;
+
+                yield Ok(process_resp.as_ref().expect("JobList is not present").clone());
+
+                page_token = match process_resp.unwrap_or_default().next_page_token {
+                    None => break,
+                    f => f.clone(),
+                };
+            }
+        }
     }
 
     /// RPC to get the results of a query job.

--- a/src/model/job.rs
+++ b/src/model/job.rs
@@ -5,11 +5,10 @@ use crate::model::job_status::JobStatus;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Job {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub configuration: Option<JobConfiguration>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "jobReference")]
     pub job_reference: Option<JobReference>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub statistics: Option<JobStatistics>,
@@ -27,9 +26,12 @@ pub struct Job {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     /// [Output-only] A URL that can be used to access this resource again.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "selfLink")]
     pub self_link: Option<String>,
     /// [Output-only] Email address of the user who ran the job.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_email: Option<String>,
+    /// [Output-only] String representation of identity of requesting party. Populated for both first- and third-party identities. Only present for APIs that support third-party identities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub principal_subject: Option<String>,
 }

--- a/src/model/job_list_jobs.rs
+++ b/src/model/job_list_jobs.rs
@@ -6,16 +6,15 @@ use crate::model::job_status::JobStatus;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct JobListJobs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub configuration: Option<JobConfiguration>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "errorResult")]
     pub error_result: Option<ErrorProto>,
     /// Unique opaque ID of the job.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "jobReference")]
     pub job_reference: Option<JobReference>,
     /// The resource type.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -25,9 +24,13 @@ pub struct JobListJobs {
     pub state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub statistics: Option<JobStatistics>,
+    /// [Full-projection-only] Describes the status of this job.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<JobStatus>,
     /// [Full-projection-only] Email address of the user who ran the job.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_email: Option<String>,
+    /// [Full-projection-only] String representation of identity of requesting party. Populated for both first- and third-party identities. Only present for APIs that support third-party identities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub principal_subject: Option<String>,
 }

--- a/src/model/job_list_parameters.rs
+++ b/src/model/job_list_parameters.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobListParameters {
+    /// Whether to display jobs owned by all users in the project. Default False.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub all_users: Option<bool>,
+    /// The maximum number of results to return in a single response page. Leverage the page tokens to iterate through the entire collection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_results: Option<u32>,
+    /// Min value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created after or at this timestamp are returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_creation_time: Option<u64>,
+    /// Max value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created before or at this timestamp are returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_creation_time: Option<u64>,
+    /// If set, show only child jobs of the specified parent. Otherwise, show all top-level jobs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_job_id: Option<String>,
+    /// Restrict information returned to a set of selected fields. Acceptable values are: full or minimal.
+    #[serde(skip_serializing_if = "Option::is_none", deserialize_with = "deserialize_projection")]
+    pub projection: Option<String>,
+    /// Filter for job state. Acceptable values are: done, pending, and running.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_state_filter"
+    )]
+    pub state_filter: Option<String>,
+    /// Page token, returned by a previous call, to request the next page of results.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_token: Option<String>,
+}
+
+fn deserialize_projection<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    match value {
+        Value::String(string) => {
+            if string == "full" || string == "minimal" {
+                Ok(Some(string))
+            } else {
+                Err(serde::de::Error::custom("Invalid string"))
+            }
+        }
+        Value::Null => Ok(None),
+        _ => Err(serde::de::Error::custom("Invalid type")),
+    }
+}
+
+fn deserialize_state_filter<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    match value {
+        Value::String(string) => {
+            if string == "done" || string == "pending" || string == "running" {
+                Ok(Some(string))
+            } else {
+                Err(serde::de::Error::custom("Invalid string"))
+            }
+        }
+        Value::Null => Ok(None),
+        _ => Err(serde::de::Error::custom("Invalid type")),
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -72,6 +72,7 @@ pub mod job_configuration_query;
 pub mod job_configuration_table_copy;
 pub mod job_list;
 pub mod job_list_jobs;
+pub mod job_list_parameters;
 pub mod job_reference;
 pub mod job_statistics;
 pub mod job_statistics2;


### PR DESCRIPTION
This PR adds a method to allow users to paginate through all the jobs in the jobs list. It is helpful as it allows people to obtain all of the jobs from the list jobs API.

Also, fix a bug in `JobListJobs` and `Job` struct, the API sends `user_email` in this format and not in camel case like in the struct.