### PR TITLE
update hyper-rustls to version 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,19 +25,30 @@ bq_load_job = ["cloud-storage"]
 
 [dependencies]
 yup-oauth2 = "8.3"
-hyper = {version="0.14", features = ["http1"]}
-hyper-rustls = {version="0.24", features = ["native-tokio"]}
+hyper = { version = "0.14", features = ["http1"] }
+hyper-rustls = { version = "0.25", features = ["native-tokio"] }
 thiserror = "1"
-tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "sync", "macros"] }
+tokio = { version = "1", default-features = false, features = [
+    "rt-multi-thread",
+    "net",
+    "sync",
+    "macros",
+] }
 tokio-stream = "0.1"
 async-stream = "0.3"
-reqwest = { version = "0.11", default-features = false, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
 url = "2"
 serde = "1"
 serde_json = "1"
 log = "0.4"
-time = { version = "0.3.22", features = ["local-offset", "serde", "serde-well-known"] }
-cloud-storage = {version="0.11.1", features = ["global-client"], optional = true}
+time = { version = "0.3.22", features = [
+    "local-offset",
+    "serde",
+    "serde-well-known",
+] }
+cloud-storage = { version = "0.11.1", features = [
+    "global-client",
+], optional = true }
 async-trait = "0.1.68"
 dyn-clone = "1.0.11"
 


### PR DESCRIPTION
There were issue using 0.26 (latest). This PR pegs hyper-rustls to use version 0.25.