### PR TITLE
add `#[serde(default)]` to `NestedResponseError:status`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -65,5 +65,6 @@ pub struct NestedResponseError {
     pub code: i64,
     pub errors: Vec<HashMap<String, String>>,
     pub message: String,
+    #[serde(default)]
     pub status: String,
 }


### PR DESCRIPTION
Hello!

I am using this library together with the bigquery-emulator. The emulator does not return the status field in error responses, and as far as i can tell the status is not a required field in error responses.

Though finding documentation about it has been hard, the sample error on in the docs does not contain a status field: https://cloud.google.com/bigquery/docs/error-messages#sample-error-response