### PR TITLE
Re-export hyper_rustls from yup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ bq_load_job = ["cloud-storage"]
 [dependencies]
 yup-oauth2 = "8.3"
 hyper = {version="0.14", features = ["http1"]}
-hyper-rustls = {version="0.25", features = ["native-tokio"]}
 thiserror = "1"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "sync", "macros"] }
 tokio-stream = "0.1"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use dyn_clone::{clone_trait_object, DynClone};
 use hyper::client::HttpConnector;
-use hyper_rustls::HttpsConnector;
+use yup_oauth2::hyper_rustls::HttpsConnector;
 use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
 use yup_oauth2::authenticator::Authenticator as YupAuthenticator;
 use yup_oauth2::authorized_user::AuthorizedUserSecret;


### PR DESCRIPTION
Just a suggestion but you could re-export rustls from yup instead of depending on it directly