### PR TITLE
pub use yup_oauth2;

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ use crate::routine::RoutineApi;
 use crate::table::TableApi;
 use crate::tabledata::TableDataApi;
 
+pub use yup_oauth2;
+
 pub mod auth;
 pub mod client_builder;
 pub mod dataset;


### PR DESCRIPTION
Since yup_oauth2 structs are used as parameters in public functions there is already semver coupling, as it is an error if consumer uses different version of yup_oauth than gcp-bigquery-client

Export yup_oauth2 so consumers don't need to carefully keep their dependency versions in sync. This also allows accessing yup_oauth2::hyper_rustls, as suggested in #85