### PR TITLE
Add GZIP support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ rust-tls = ["reqwest/rustls-tls"]
 # Feature used to remove cloud-storage from the standard build.
 # cloud-storage has a dependency on chrono, so the feature is there to remove this dependency by default.
 bq_load_job = ["cloud-storage"]
+gzip = ["flate2"]
+
+[dependencies.flate2]
+version = "1.0"
+optional = true
 
 [dependencies]
 yup-oauth2 = "8.3"


### PR DESCRIPTION
This PR adds data compression using GZIP in the `insert_all` method.

Currently, I don't have access to a BigQuery instance to test it. If you have the opportunity to verify it, please do it, so I can address any issues that arise.

#74 