### PR TITLE
Add GZIP support (2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rust-tls = ["reqwest/rustls-tls"]
 bq_load_job = ["cloud-storage"]
 
 [dependencies]
+flate2 = "1.0"
 yup-oauth2 = "10.0.1"
 rustls = { version="0.23.10" }
 hyper = { version = "1.3.1", features = ["http1"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ use crate::tabledata::TableDataApi;
 /// (see https://github.com/lquerel/gcp-bigquery-client/pull/86)
 pub use yup_oauth2;
 
+pub use flate2::Compression;
+
 pub mod auth;
 pub mod client_builder;
 pub mod dataset;


### PR DESCRIPTION
This PR adds GZIP data compression to the insert_all method and enables configurable compression through an additional parameter.


Currently, I don't have access to a BigQuery instance to test it. If you have the opportunity to verify it, please do it, so I can address any issues that arise.

https://github.com/lquerel/gcp-bigquery-client/issues/74