### PR TITLE
yup-oauth2 11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,17 @@ keywords = ["gcp", "bigquery", "google-cloud"]
 categories = ["database"]
 
 [features]
-default = ["rust-tls"]
+default = ["rust-tls", "ring"]
 native-tls = ["reqwest/native-tls"]
 rust-tls = ["reqwest/rustls-tls"]
+ring = ["yup-oauth2/ring"]
+aws-lc-rs = ["yup-oauth2/aws-lc-rs"]
 # Feature used to remove cloud-storage from the standard build.
 # cloud-storage has a dependency on chrono, so the feature is there to remove this dependency by default.
 bq_load_job = ["cloud-storage"]
 
 [dependencies]
-yup-oauth2 = "10.0.1"
-rustls = { version="0.23.10" }
+yup-oauth2 = { version = "11", default-features = false, features = ["hyper-rustls", "service-account"] }
 hyper = { version = "1.3.1", features = ["http1"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-legacy"] }
 thiserror = "1.0.59"

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -17,11 +17,6 @@ pub struct ClientBuilder {
 
 impl ClientBuilder {
     pub fn new() -> Self {
-        // Note: There might be a better way to define the default provider for cryptography, but
-        // for now, without this call, the following message is produced by rustls:
-        // no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point
-        let _ = rustls::crypto::ring::default_provider().install_default();
-
         Self {
             v2_base_url: BIG_QUERY_V2_URL.to_string(),
             auth_base_url: BIG_QUERY_AUTH_URL.to_string(),


### PR DESCRIPTION
crypto provider issues resolved with this version, added 2 features so consumers of library can choose: ring / aws-lc-rs, matching naming convention in yup-oauth2