### PR TITLE
fix clippy warnings produced with Rust 1.78.0

### DIFF
--- a/src/model/argument.rs
+++ b/src/model/argument.rs
@@ -18,7 +18,7 @@ pub struct Argument {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Mode {
-    ///
+    /// Unspecified mode
     ModeUnspecified,
     /// The argument is input-only.
     In,
@@ -32,7 +32,7 @@ pub enum Mode {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ArgumentKind {
-    ///
+    /// Unspecified argument kind
     ArgumentKindUnspecified,
     /// The argument is a variable with fully specified type, which can be a struct or an array, but not a table.
     FixedType,

--- a/src/model/arima_forecasting_metrics.rs
+++ b/src/model/arima_forecasting_metrics.rs
@@ -23,7 +23,7 @@ pub struct ArimaForecastingMetrics {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SeasonalPeriods {
-    ///
+    /// Unspecified seasonal period type
     SeasonalPeriodTypeUnspecified,
     /// No seasonality
     NoSeasonality,

--- a/src/model/arima_model_info.rs
+++ b/src/model/arima_model_info.rs
@@ -23,7 +23,7 @@ pub struct ArimaModelInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SeasonalPeriods {
-    ///
+    /// Unspecified seasonal period type
     SeasonalPeriodTypeUnspecified,
     /// No seasonality
     NoSeasonality,

--- a/src/model/arima_result.rs
+++ b/src/model/arima_result.rs
@@ -13,7 +13,7 @@ pub struct ArimaResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SeasonalPeriods {
-    ///
+    /// Unspecified seasonal period type
     SeasonalPeriodTypeUnspecified,
     /// No seasonality
     NoSeasonality,

--- a/src/model/arima_single_model_forecasting_metrics.rs
+++ b/src/model/arima_single_model_forecasting_metrics.rs
@@ -20,7 +20,7 @@ pub struct ArimaSingleModelForecastingMetrics {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SeasonalPeriods {
-    ///
+    /// Unspecified seasonal period type
     SeasonalPeriodTypeUnspecified,
     /// No seasonality
     NoSeasonality,

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -41,7 +41,7 @@ pub struct Model {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ModelType {
-    ///
+    /// Unspecified model type
     ModelTypeUnspecified,
     /// Linear regression model.
     LinearRegression,

--- a/src/model/routine.rs
+++ b/src/model/routine.rs
@@ -36,7 +36,7 @@ pub struct Routine {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RoutineType {
-    ///
+    /// Unspecified routine type
     RoutineTypeUnspecified,
     /// Non-builtin permanent scalar function.
     ScalarFunction,
@@ -48,7 +48,7 @@ pub enum RoutineType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Language {
-    ///
+    /// Unspecified language
     LanguageUnspecified,
     /// SQL language.
     Sql,

--- a/src/model/training_options.rs
+++ b/src/model/training_options.rs
@@ -97,7 +97,7 @@ pub struct TrainingOptions {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FeedbackType {
-    ///
+    /// Unspecified feedback type
     FeedbackTypeUnspecified,
     /// Use weighted-als for implicit feedback problems.
     Implicit,
@@ -109,7 +109,7 @@ pub enum FeedbackType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DistanceType {
-    ///
+    /// Unspecified distance type
     DistanceTypeUnspecified,
     /// Eculidean distance.
     Euclidean,
@@ -121,7 +121,7 @@ pub enum DistanceType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OptimizationStrategy {
-    ///
+    /// Unspecified optimization strategy
     OptimizationStrategyUnspecified,
     /// Uses an iterative batch gradient descent algorithm.
     BatchGradientDescent,
@@ -133,7 +133,7 @@ pub enum OptimizationStrategy {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DataSplitMethod {
-    ///
+    /// Unspecified data split method
     DataSplitMethodUnspecified,
     /// Splits data randomly.
     Random,
@@ -151,7 +151,7 @@ pub enum DataSplitMethod {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum LossType {
-    ///
+    /// Unspecified loss type
     LossTypeUnspecified,
     /// Mean squared loss, used for linear regression.
     MeanSquaredLoss,
@@ -163,7 +163,7 @@ pub enum LossType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum LearnRateStrategy {
-    ///
+    /// Unspecified learn rate strategy
     LearnRateStrategyUnspecified,
     /// Use line search to determine learning rate.
     LineSearch,
@@ -333,7 +333,7 @@ pub enum HolidayRegion {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DataFrequency {
-    ///
+    /// Unspecified data frequency
     DataFrequencyUnspecified,
     /// Automatically inferred from timestamps.
     AutoFrequency,


### PR DESCRIPTION
Most clippy warnings were about empty doc comments. One was about using `clone_from` instead of `clone` which needed a bit of code reorg.