### PR TITLE
make ResultSet more general

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.23.0] - 2024-08-28
+## [0.24.0] - 2024-08-28
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ All notable changes to this project will be documented in this file.
 
 ### Maintenance
 
-- # Bump versions of `thiserror`, `hyper-util`, `tokio`, `serde`, `serde_json`, `tonic`, `tonic-build`.
+- Bump versions of `thiserror`, `hyper-util`, `tokio`, `serde`, `serde_json`, `tonic`, `tonic-build`.
 
 ## [0.22.0] - 2024-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.0] - 2024-08-28
+
+#### Changed
+
+- Added a new method `ResultSet::new_from_get_query_results_response` which creates a `ResultSet` from a `GetQueryResultsResponse`.
+
+- Breaking changes:
+
+  - Return type of `JobApi::query` changed from `Result<ResultSet, BQError>` to `Result<QueryResponse, BQError>`.
+  - `ResultSet::new` renamed to `ResultSet::new_from_query_response`.
+
+- Rationale for the breaking changes:
+
+  `JobApi::query` now returns `Result<QueryResponse, BQError>` instead of `Result<ResultSet, BQError>`. A `ResultSet` wraps over a `QueryResponse` but callers didn't have acces to that internal object. To allow callers access to the internal object, `JobApi::query` now returns the internal object itself. This means older code which expected a `ResultSet` will break.
+
+- Upgrading to the new version:
+
+  To fix broken code, you'll have to call `ResultSet::from_query_response` function. For example, if your code looked like this:
+
+  ```rust
+  let mut result_set = client
+        .job()
+        .query(
+            project_id,
+            query_request,
+        )
+        .await?;
+  ```
+
+  It should be updated to:
+
+  ```rust
+  let query_response = client
+        .job()
+        .query(
+            project_id,
+            query_request,
+        )
+        .await?;
+    let mut result_set = ResultSet::new_from_query_response(query_response);
+  ```
+
+  Another reason for the change was making it consistent with `JobApi::get_query_results` which already returned an unwrapped object which callers needed to manually wrap inside a `ResultSet` by calling `ResultSet::new` method.
+
 ## [0.23.0] - 2024-08-10
 
 ### Fix
@@ -11,21 +55,22 @@ All notable changes to this project will be documented in this file.
 
 ### Maintenance
 
-- Bump versions of `thiserror`, `hyper-util`, `tokio`, `serde`, `serde_json`, `tonic`, `tonic-build`.
+- # Bump versions of `thiserror`, `hyper-util`, `tokio`, `serde`, `serde_json`, `tonic`, `tonic-build`.
 
 ## [0.22.0] - 2024-07-07
 
 ### Added
 
-- Add partial support for BigQuery Storage Write API (by @imor). 
+- Add partial support for BigQuery Storage Write API (by @imor).
   - append_rows
   - get_write_stream
 - Add GZIP support for `insert_all` (by @Deniskore). The `gzip` feature is included by default.
   See https://github.com/lquerel/gcp-bigquery-client/issues/74 for more information.
 
 Breaking changes:
-  - Client::from_authenticator is now async.
-  - ClientBuilder::build_from_authenticator is now async.
+
+- Client::from_authenticator is now async.
+- ClientBuilder::build_from_authenticator is now async.
 
 ### Maintenance
 
@@ -59,7 +104,7 @@ Breaking changes:
 - Add support to bigquery-emulator (Thanks to @henriiik)
 - Add support to use the ClientBuilder to build a Client with an Authenticator (Thanks to @henriiik)
 
-### Fix 
+### Fix
 
 - Fix build issue with hyper-rustls (Thanks to @OmriSteiner and @nate-kelley-buster)
 
@@ -220,10 +265,9 @@ Breaking changes:
 
 ## [0.9.3] - 2021-08-31
 
-### Fix 
+### Fix
 
 - Fix ResultSet.get_i64 not working with some valid integer notation (e.g. 123.45E4) (Thanks to @komi1230).
-
 
 ## [0.9.2] - 2021-08-30
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ rows are based on a regular Rust struct implementing the trait Serialize.
         .await?;
 
     // Query
-    let mut rs = client
+    let mut query_response = client
         .job()
         .query(
             project_id,
@@ -198,6 +198,7 @@ rows are based on a regular Rust struct implementing the trait Serialize.
             )),
         )
         .await?;
+    let mut rs = ResultSet::new_from_query_response(query_response);
     while rs.next_row() {
         println!("Number of rows inserted: {}", rs.get_i64_by_name("c")?.unwrap());
     }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,6 +1,5 @@
 use serde::Serialize;
 
-use gcp_bigquery_client::env_vars;
 use gcp_bigquery_client::error::BQError;
 use gcp_bigquery_client::model::dataset::Dataset;
 use gcp_bigquery_client::model::query_request::QueryRequest;
@@ -9,6 +8,7 @@ use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAl
 use gcp_bigquery_client::model::table_field_schema::TableFieldSchema;
 use gcp_bigquery_client::model::table_schema::TableSchema;
 use gcp_bigquery_client::model::time_partitioning::TimePartitioning;
+use gcp_bigquery_client::{env_vars, model::query_response::ResultSet};
 use std::time::{Duration, SystemTime};
 use time::OffsetDateTime;
 
@@ -185,7 +185,7 @@ async fn main() -> Result<(), BQError> {
         .await?;
 
     // Query
-    let mut rs = client
+    let query_response = client
         .job()
         .query(
             project_id,
@@ -194,6 +194,7 @@ async fn main() -> Result<(), BQError> {
             )),
         )
         .await?;
+    let mut rs = ResultSet::new_from_query_response(query_response);
     while rs.next_row() {
         println!("Number of rows inserted: {}", rs.get_i64_by_name("c")?.unwrap());
     }

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -92,7 +92,7 @@ mod bq {
     use fake::{Fake, StringFaker};
     use gcp_bigquery_client::{
         model::{
-            dataset::Dataset, query_request::QueryRequest, table::Table,
+            dataset::Dataset, query_request::QueryRequest, query_response::ResultSet, table::Table,
             table_data_insert_all_request::TableDataInsertAllRequest, table_field_schema::TableFieldSchema,
             table_schema::TableSchema,
         },
@@ -179,7 +179,7 @@ mod bq {
         }
 
         pub async fn get_rows(&self) -> Vec<String> {
-            let mut rs = self
+            let query_response = self
                 .client
                 .job()
                 .query(
@@ -192,6 +192,7 @@ mod bq {
                 .await
                 .unwrap();
 
+            let mut rs = ResultSet::new_from_query_response(query_response);
             let mut rows: Vec<String> = vec![];
             while rs.next_row() {
                 let name = rs.get_string_by_name(NAME_COLUMN).unwrap().unwrap();

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -340,7 +340,7 @@ impl DatasetApi {
         let resp = self.client.execute(request).await?;
 
         let query_response: QueryResponse = process_response(resp).await?;
-        let mut rs = ResultSet::new(query_response);
+        let mut rs = ResultSet::new_from_query_response(query_response);
         let mut result = vec![];
         let catalog_name_pos = *rs
             .column_index("catalog_name")


### PR DESCRIPTION
NOTE: review and merge the following PR first: https://github.com/lquerel/gcp-bigquery-client/pull/96. This is because this PR's branch is cut from the previous PR's branch.

This PR makes `ResultSet` more general by only holding onto a `Vec<TableRow>` instead of a `QueryResponse`. This change makes it possible to create a `ResultSet` not only from a `QueryResponse` but also from a `GetQueryResultsResponse`. Need for this arose when I wanted to create a single function which will first call `JobApi::query` and if it returns `job_complete=false` then fall back to polling `JobApi::get_query_results` to get the results when the query job finishes. Such a function needed the ability to create a `ResultSet` from the results of either of these APIs. This is the function I wrote that uses the refactored code:

```rust
async fn query(&self, query: String) -> Result<ResultSet, BQError> {
        let query_response = self
            .client
            .job()
            .query(&self.project_id, QueryRequest::new(query))
            .await?;

        if query_response.job_complete.unwrap_or(false) {
            info!("job complete. returning result set");
            Ok(ResultSet::new_from_query_response(query_response))
        } else {
            let job_id = query_response
                .job_reference
                .as_ref()
                .expect("missing job reference")
                .job_id
                .as_ref()
                .expect("missing job id");
            loop {
                info!("job incomplete. waiting for 5 seconds");
                sleep(Duration::from_secs(5)).await;
                let result = self
                    .client
                    .job()
                    .get_query_results(&self.project_id, job_id, Default::default())
                    .await?;
                if result.job_complete.unwrap_or(false) {
                    info!("job complete. returning result set");
                    let result_set = ResultSet::new_from_get_query_results_response(result);
                    break Ok(result_set);
                }
            }
        }
    }
```

Note: This is a breaking API change, so should be included only in a major version bumped release.