### PR TITLE
install protoc in gh actions

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -16,6 +16,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: arduino/setup-protoc@v3
       - env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         run: echo $GOOGLE_APPLICATION_CREDENTIALS > GOOGLE_APPLICATION_CREDENTIALS.json
@@ -53,11 +54,11 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
+      - uses: arduino/setup-protoc@v3
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -D warnings
-
 #  coverage:
 #    name: Code coverage
 #    runs-on: ubuntu-latest

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
-        .build_server(false)
-        .compile(
-            &["googleapis/google/cloud/bigquery/storage/v1/storage.proto"],
-            &["googleapis"],
-        )?;
+    tonic_build::configure().build_server(false).compile(
+        &["googleapis/google/cloud/bigquery/storage/v1/storage.proto"],
+        &["googleapis"],
+    )?;
     Ok(())
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,6 +8,7 @@ use tonic::{
     Request, Streaming,
 };
 
+use crate::google::cloud::bigquery::storage::v1::{GetWriteStreamRequest, WriteStream, WriteStreamView};
 use crate::{
     auth::Authenticator,
     error::BQError,
@@ -18,7 +19,6 @@ use crate::{
     },
     BIG_QUERY_V2_URL,
 };
-use crate::google::cloud::bigquery::storage::v1::{GetWriteStreamRequest, WriteStream, WriteStreamView};
 
 static BIG_QUERY_STORAGE_API_URL: &str = "https://bigquerystorage.googleapis.com";
 static BIGQUERY_STORAGE_API_DOMAIN: &str = "bigquerystorage.googleapis.com";
@@ -264,16 +264,16 @@ impl StorageApi {
 
 #[cfg(test)]
 pub mod test {
-    use std::time::{Duration, SystemTime};
-    use prost::Message;
-    use tokio_stream::StreamExt;
-    use crate::{Client, env_vars};
     use crate::model::dataset::Dataset;
     use crate::model::field_type::FieldType;
     use crate::model::table::Table;
     use crate::model::table_field_schema::TableFieldSchema;
     use crate::model::table_schema::TableSchema;
     use crate::storage::{ColumnType, FieldDescriptor, StreamName, TableDescriptor};
+    use crate::{env_vars, Client};
+    use prost::Message;
+    use std::time::{Duration, SystemTime};
+    use tokio_stream::StreamExt;
 
     #[tokio::test]
     async fn test() -> Result<(), Box<dyn std::error::Error>> {
@@ -312,7 +312,6 @@ pub mod test {
             )
             .await?;
         assert_eq!(created_table.table_reference.table_id, table_id.to_string());
-
 
         // let (ref project_id, ref dataset_id, ref table_id, ref gcp_sa_key) = env_vars();
         //


### PR DESCRIPTION
This PR installs the protoc compiler before running tests and clippy to avoid their failure since we now depend on it to compile the Storage Write API support.