### PR TITLE
fix error about invalid certificate when calling `append_rows` api

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -140,7 +140,9 @@ impl StorageApi {
     }
 
     pub(crate) async fn new_write_client() -> Result<BigQueryWriteClient<Channel>, BQError> {
-        let tls_config = ClientTlsConfig::new().domain_name(BIGQUERY_STORAGE_API_DOMAIN);
+        let tls_config = ClientTlsConfig::new()
+            .domain_name(BIGQUERY_STORAGE_API_DOMAIN)
+            .with_native_roots();
         let channel = Channel::from_static(BIG_QUERY_STORAGE_API_URL)
             .tls_config(tls_config)?
             .connect()


### PR DESCRIPTION
When running the `append_rows` api, the following error was thrown:

```
Error: TonicTransportError(tonic::transport::Error(Transport, ConnectError(Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) })))
```

This was because tonic made a [breaking change](https://github.com/hyperium/tonic/pull/1731) in version `0.12.0`. To fix this we'd need to call `with_native_roots` method on the `ClientTlsConfig` object.