### PR TITLE
chore: add TableValuedFunction routine type

### DIFF
--- a/src/model/routine.rs
+++ b/src/model/routine.rs
@@ -17,7 +17,7 @@ pub struct Routine {
     /// Required. The body of the routine. For functions, this is the expression in the AS clause. If language=SQL, it is the substring inside (but excluding) the parentheses. For example, for the function created with the following statement: `CREATE FUNCTION JoinLines(x string, y string) as (concat(x, "\n", y))` The definition_body is `concat(x, "\n", y)` (\n is not replaced with linebreak). If language=JAVASCRIPT, it is the evaluated string in the AS clause. For example, for the function created with the following statement: `CREATE FUNCTION f() RETURNS STRING LANGUAGE js AS 'return "\n";\n'` The definition_body is `return "\n";\n` Note that both \n are replaced with linebreaks.
     pub definition_body: String,
     /// Output only. The time when this routine was created, in milliseconds since the epoch.
-    pub creation_time: Option<i64>,
+    pub creation_time: Option<String>,
     /// Optional. [Experimental] The determinism level of the JavaScript UDF if defined.
     pub determinism_level: Option<DeterminismLevel>,
     /// Optional. [Experimental] The description of the routine if defined.
@@ -29,7 +29,7 @@ pub struct Routine {
     /// Required. Reference describing the ID of this routine.
     pub routine_reference: RoutineReference,
     /// Output only. The time when this routine was last modified, in milliseconds since the epoch.
-    pub last_modified_time: Option<i64>,
+    pub last_modified_time: Option<String>,
 }
 
 /// Required. The type of routine.

--- a/src/model/routine.rs
+++ b/src/model/routine.rs
@@ -42,6 +42,8 @@ pub enum RoutineType {
     ScalarFunction,
     /// Stored procedure.
     Procedure,
+    /// Non-built-in persistent TVF.
+    TableValuedFunction,
 }
 
 /// Optional. Defaults to "SQL".


### PR DESCRIPTION
This PR is to add missing routine type `TableValuedFunction` as specified in the [reference](https://cloud.google.com/bigquery/docs/reference/rest/v2/routines#RoutineType).
It also fixes the data type of `creation_time` and `last_modified_time` to `String` type. [refer](https://cloud.google.com/bigquery/docs/reference/rest/v2/routines)