### PR TITLE
Draft: Add Message and Enum support for Storage Write API

### DIFF
--- a/examples/append_rows.rs
+++ b/examples/append_rows.rs
@@ -1,6 +1,6 @@
 use gcp_bigquery_client::{
     env_vars,
-    storage::{ColumnType, FieldDescriptor, StreamName, TableDescriptor},
+    storage::{FieldDescriptor, StreamName, TableDescriptor},
 };
 use prost::Message;
 use tokio_stream::StreamExt;
@@ -12,28 +12,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = gcp_bigquery_client::Client::from_service_account_key_file(gcp_sa_key).await?;
 
     let field_descriptors = vec![
-        FieldDescriptor {
-            name: "actor_id".to_string(),
-            number: 1,
-            typ: ColumnType::Int64,
-        },
-        FieldDescriptor {
-            name: "first_name".to_string(),
-            number: 2,
-            typ: ColumnType::String,
-        },
-        FieldDescriptor {
-            name: "last_name".to_string(),
-            number: 3,
-            typ: ColumnType::String,
-        },
-        FieldDescriptor {
-            name: "last_update".to_string(),
-            number: 4,
-            typ: ColumnType::Timestamp,
-        },
+        FieldDescriptor::int64("actor_id".to_string(), 1),
+        FieldDescriptor::string("first_name".to_string(), 2),
+        FieldDescriptor::string("last_name".to_string(), 3),
+        FieldDescriptor::timestamp("last_update".to_string(), 4),
     ];
-    let table_descriptor = TableDescriptor { field_descriptors };
+    let table_descriptor = TableDescriptor::new(field_descriptors);
 
     #[derive(Clone, PartialEq, Message)]
     struct Actor {


### PR DESCRIPTION
This PR is based on #112, so I'll leave it as a draft until that is merged (and I assume the same test failure there will show up here). I also want to add unit tests for messages and enums before this gets merged.

I went ahead and added some convenience constructors to help reduce breaking changes for people that are using simple, flat protos. Even though I'm pretty sure this change gives us full support all types BigQuery has documented, I imagine as this gets used we'll run into some quirks in BigQuery that may require further changes to accommodate.