### PR TITLE
Limit request size to under 10 MB for AppendRows API

### DIFF
--- a/examples/append_rows.rs
+++ b/examples/append_rows.rs
@@ -71,7 +71,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stream_name = StreamName::new_default(project_id.clone(), dataset_id.clone(), table_id.clone());
     let trace_id = "test_client".to_string();
 
-    let (rows, _) = StorageApi::create_rows(&table_descriptor, &[actor1, actor2]);
+    const MAX_SIZE: usize = 9 * 1024 * 1024; // 9 MB
+    let (rows, _) = StorageApi::create_rows(&table_descriptor, &[actor1, actor2], MAX_SIZE);
     let mut streaming = client.storage_mut().append_rows(&stream_name, rows, trace_id).await?;
 
     while let Some(resp) = streaming.next().await {

--- a/examples/append_rows.rs
+++ b/examples/append_rows.rs
@@ -1,6 +1,6 @@
 use gcp_bigquery_client::{
     env_vars,
-    storage::{ColumnMode, ColumnType, FieldDescriptor, StreamName, TableDescriptor},
+    storage::{ColumnMode, ColumnType, FieldDescriptor, StorageApi, StreamName, TableDescriptor},
 };
 use prost::Message;
 use tokio_stream::StreamExt;
@@ -71,10 +71,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stream_name = StreamName::new_default(project_id.clone(), dataset_id.clone(), table_id.clone());
     let trace_id = "test_client".to_string();
 
-    let mut streaming = client
-        .storage_mut()
-        .append_rows(&stream_name, &table_descriptor, &[actor1, actor2], trace_id)
-        .await?;
+    let rows = StorageApi::create_rows(&table_descriptor, &[actor1, actor2]);
+    let mut streaming = client.storage_mut().append_rows(&stream_name, rows, trace_id).await?;
 
     while let Some(resp) = streaming.next().await {
         let resp = resp?;

--- a/examples/append_rows.rs
+++ b/examples/append_rows.rs
@@ -1,6 +1,6 @@
 use gcp_bigquery_client::{
     env_vars,
-    storage::{ColumnType, FieldDescriptor, StreamName, TableDescriptor},
+    storage::{ColumnMode, ColumnType, FieldDescriptor, StreamName, TableDescriptor},
 };
 use prost::Message;
 use tokio_stream::StreamExt;
@@ -16,21 +16,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             name: "actor_id".to_string(),
             number: 1,
             typ: ColumnType::Int64,
+            mode: ColumnMode::Required,
         },
         FieldDescriptor {
             name: "first_name".to_string(),
             number: 2,
             typ: ColumnType::String,
+            mode: ColumnMode::Required,
         },
         FieldDescriptor {
             name: "last_name".to_string(),
             number: 3,
             typ: ColumnType::String,
+            mode: ColumnMode::Required,
         },
         FieldDescriptor {
             name: "last_update".to_string(),
             number: 4,
-            typ: ColumnType::Timestamp,
+            typ: ColumnType::String,
+            mode: ColumnMode::Required,
         },
     ];
     let table_descriptor = TableDescriptor { field_descriptors };

--- a/examples/append_rows.rs
+++ b/examples/append_rows.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stream_name = StreamName::new_default(project_id.clone(), dataset_id.clone(), table_id.clone());
     let trace_id = "test_client".to_string();
 
-    let rows = StorageApi::create_rows(&table_descriptor, &[actor1, actor2]);
+    let (rows, _) = StorageApi::create_rows(&table_descriptor, &[actor1, actor2]);
     let mut streaming = client.storage_mut().append_rows(&stream_name, rows, trace_id).await?;
 
     while let Some(resp) = streaming.next().await {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -244,7 +244,7 @@ impl StorageApi {
     pub fn create_rows<M: Message>(
         table_descriptor: &TableDescriptor,
         rows: &[M],
-        max_size: usize,
+        max_size_bytes: usize,
     ) -> (append_rows_request::Rows, usize) {
         let field_descriptors = table_descriptor
             .field_descriptors
@@ -290,7 +290,7 @@ impl StorageApi {
             let encoded_row = row.encode_to_vec();
             let current_size = encoded_row.len();
 
-            if total_size + current_size > max_size {
+            if total_size + current_size > max_size_bytes {
                 break;
             }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -467,11 +467,12 @@ pub mod test {
         .await?;
         assert_eq!(num_append_rows_calls, 1);
 
-        // artifically limit the size of the rows to test the loop
-        let max_size = 9 * 1024 * 1024; // 9 MB
+        // It was found after experimenting that one row in this test encodes to about 38 bytes
+        // We artificially limit the size of the rows to test that the loop processes all the rows
+        let max_size = 50; // 50 bytes
         let num_append_rows_calls =
             call_append_rows(&mut client, &table_descriptor, &stream_name, trace_id, rows, max_size).await?;
-        assert_eq!(num_append_rows_calls, 1);
+        assert_eq!(num_append_rows_calls, 2);
 
         Ok(())
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -224,6 +224,23 @@ impl StorageApi {
         Ok(streaming)
     }
 
+    /// This function encodes the `rows` slice into a protobuf message
+    /// while ensuring that the total size of the encoded rows does
+    /// not exceed the `max_size` argument. The encoded rows are returned
+    /// in the first value of the tuple returned by this function.
+    ///
+    /// Note that it is possible that not all the rows in the `rows` slice
+    /// were encoded due to the `max_size` limit.  The callers can find
+    /// out how many rows were processed by looking at the second value in
+    /// the tuple returned by this function. If the number of rows processed
+    /// is less than the number of rows in the `rows` slice, then the caller
+    /// can call this function again with the rows remaing at the end of the
+    /// slice to encode them.
+    ///
+    /// The AppendRows API has a payload size limit of 10MB. Some of the
+    /// space in the 10MB limit is used by the request metadata, so the
+    /// `max_size` argument should be set to a value less than 10MB. 9MB
+    /// is a good value to use for the `max_size` argument.
     pub fn create_rows<M: Message>(
         table_descriptor: &TableDescriptor,
         rows: &[M],


### PR DESCRIPTION
There's a 10 MB limit on the request size in BigQuery as documented on [this page](https://cloud.google.com/bigquery/quotas) (search `maximum request size`). If the request size goes over this limit, the `AppendRows` API returns an `INVALID_ARGUMENT` error. This PR limits the serialized rows size to 9 MB and leaves around 1 MB for the other parts of the request (this can probably also be made configurable). But more importantly, the `append_rows` function now accepts a `Rows` struct rather than a `&[Message]` which allows callers to create the `Rows` struct using any strategy they want (e.g. repeatedly halving  the `Rows` size while the API continues to return `INVALID_ARGUMENT`). This API design is better than the existing one in which the `append_rows` created the `Rows` struct from `&[Message]` slice, which left no control in callers' hands. This unfortunately breaks backward compatibility but can be shipped in the next major version bump.