### PR TITLE
Reduce dependency (axum)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ async-trait = "0.1.83"
 dyn-clone = "1.0.17"
 prost = "0.13.3"
 prost-types = "0.13.3"
-tonic = { version = "0.12.3", features = ["transport", "tls", "tls-roots"] }
+tonic = { version = "0.12.3", default-features = false, features = ["channel", "codegen", "prost", "tls", "tls-roots"] }
 
 [dev-dependencies]
 tokio-test = "0.4.4"


### PR DESCRIPTION
Would it be possible to enable tonic's `channel` feature instead of `transport` feature? `transport` feature depends on axum (via `server` feature and `router` feature) and it seems to be unnecessary for gcp-bigquery-client.

The features of tonic are as follows.

> ```toml
> [features]
> codegen = ["dep:async-trait"]
> gzip = ["dep:flate2"]
> zstd = ["dep:zstd"]
> default = ["transport", "codegen", "prost"]
> prost = ["dep:prost"]
> tls = ["dep:rustls-pemfile", "dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"]
> tls-roots = ["tls-native-roots"] # Deprecated. Please use `tls-native-roots` instead.
> tls-native-roots = ["tls", "channel", "dep:rustls-native-certs"]
> tls-webpki-roots = ["tls", "channel", "dep:webpki-roots"]
> router = ["dep:axum", "dep:tower", "tower?/util"]
> server = [
>   "router",
>   "dep:async-stream",
>   "dep:h2",
>   "dep:hyper", "hyper?/server",
>   "dep:hyper-util", "hyper-util?/service", "hyper-util?/server-auto",
>   "dep:socket2",
>   "dep:tokio", "tokio?/macros", "tokio?/net", "tokio?/time",
>   "tokio-stream/net",
>   "dep:tower", "tower?/util", "tower?/limit",
> ]
> channel = [
>   "dep:hyper", "hyper?/client",
>   "dep:hyper-util", "hyper-util?/client-legacy",
>   "dep:tower", "tower?/balance", "tower?/buffer", "tower?/discover", "tower?/limit", "tower?/util",
>   "dep:tokio", "tokio?/time",
>   "dep:hyper-timeout",
> ]
> transport = ["server", "channel"]
> ```

https://github.com/hyperium/tonic/blob/v0.12.3/tonic/Cargo.toml#L25-L54