### PR TITLE
fix: update yup-oauth2 dependency to fix rustsec-2025-0134

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ version = "1.1.2"
 optional = true
 
 [dependencies]
-yup-oauth2 = { version = "12.1.0", default-features = false, features = [
+yup-oauth2 = { version = "12.1.2", default-features = false, features = [
     "hyper-rustls", "service-account"
 ] }
 hyper-util = { version = "0.1.16", default-features = false, features = [


### PR DESCRIPTION
Hello @lquerel 👋 ,

`yup-oauth2` merged this PR https://github.com/dermesser/yup-oauth2/pull/252 to get rid of the unmaintained `rustls-pemfile`.

See [RUSTSEC-2025-0134](https://rustsec.org/advisories/RUSTSEC-2025-0134.html).

The latest version `yup-oauth2 = 12.1.2` includes this fix.

Can you please bump the version of gcp-bigquery-client on crates.io afterwards? :)

