### PR TITLE
feat(storage): Rework append concurrent method and improve connection handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ tonic-prost = "0.14.1"
 futures = "0.3.31"
 pin-project = "1.1.10"
 deadpool = "0.12.3"
+tracing = "0.1"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tonic-prost = "0.14.1"
 futures = "0.3.31"
 pin-project = "1.1.10"
 deadpool = "0.12.3"
-tracing = "0.1"
+tracing = "0.1.44"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -57,7 +57,7 @@ impl ClientBuilder {
     }
 
     pub async fn build_from_authenticator(&self, auth: Arc<dyn Authenticator>) -> Result<Client, BQError> {
-        let http_client = self.client.clone().unwrap_or_else(reqwest::Client::new);
+        let http_client = self.client.clone().unwrap_or_default();
 
         let mut dataset_api = DatasetApi::new(http_client.clone(), Arc::clone(&auth));
         let mut table_api = TableApi::new(http_client.clone(), Arc::clone(&auth));

--- a/src/google/google.api.rs
+++ b/src/google/google.api.rs
@@ -587,10 +587,8 @@ pub struct JavaSettings {
     /// - google.pubsub.v1.Publisher: TopicAdmin
     /// - google.pubsub.v1.Subscriber: SubscriptionAdmin
     #[prost(map = "string, string", tag = "2")]
-    pub service_class_names: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub service_class_names:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// Some settings.
     #[prost(message, optional, tag = "3")]
     pub common: ::core::option::Option<CommonLanguageSettings>,
@@ -635,20 +633,14 @@ pub struct DotnetSettings {
     /// fully-qualified.)
     /// Example: Subscriber to SubscriberServiceApi.
     #[prost(map = "string, string", tag = "2")]
-    pub renamed_services: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub renamed_services: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// Map from full resource types to the effective short name
     /// for the resource. This is used when otherwise resource
     /// named from different services would cause naming collisions.
     /// Example entry:
     /// "datalabeling.googleapis.com/Dataset": "DataLabelingDataset"
     #[prost(map = "string, string", tag = "3")]
-    pub renamed_resources: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub renamed_resources: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// List of full resource types to ignore during generation.
     /// This is typically used for API-specific Location resources,
     /// which should be handled by the generator as if they were actually
@@ -659,9 +651,7 @@ pub struct DotnetSettings {
     /// Namespaces which must be aliased in snippets due to
     /// a known (but non-generator-predictable) naming collision
     #[prost(string, repeated, tag = "5")]
-    pub forced_namespace_aliases: ::prost::alloc::vec::Vec<
-        ::prost::alloc::string::String,
-    >,
+    pub forced_namespace_aliases: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Method signatures (in the form "service.method(signature)")
     /// which are provided separately, so shouldn't be generated.
     /// Snippets *calling* these methods are still generated, however.
@@ -1071,17 +1061,7 @@ pub struct ResourceDescriptor {
 pub mod resource_descriptor {
     /// A description of the historical or future-looking state of the
     /// resource pattern.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum History {
         /// The "unset" value.
@@ -1117,17 +1097,7 @@ pub mod resource_descriptor {
         }
     }
     /// A flag representing a specific style that a resource claims to conform to.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Style {
         /// The unspecified value. Do not use.

--- a/src/google/google.cloud.bigquery.storage.v1.rs
+++ b/src/google/google.cloud.bigquery.storage.v1.rs
@@ -34,17 +34,7 @@ pub struct ArrowSerializationOptions {
 /// Nested message and enum types in `ArrowSerializationOptions`.
 pub mod arrow_serialization_options {
     /// Compression codec's supported by Arrow.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum CompressionCodec {
         /// If unspecified no compression will be used.
@@ -241,17 +231,7 @@ pub mod table_field_schema {
         #[prost(enumeration = "Type", tag = "1")]
         pub r#type: i32,
     }
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Type {
         /// Illegal value
@@ -339,17 +319,7 @@ pub mod table_field_schema {
             }
         }
     }
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Mode {
         /// Illegal value
@@ -533,19 +503,11 @@ pub mod read_session {
         pub sample_percentage: ::core::option::Option<f64>,
         /// Optional. Set response_compression_codec when creating a read session to
         /// enable application-level compression of ReadRows responses.
-        #[prost(
-            enumeration = "table_read_options::ResponseCompressionCodec",
-            optional,
-            tag = "6"
-        )]
+        #[prost(enumeration = "table_read_options::ResponseCompressionCodec", optional, tag = "6")]
         pub response_compression_codec: ::core::option::Option<i32>,
-        #[prost(
-            oneof = "table_read_options::OutputFormatSerializationOptions",
-            tags = "3, 4"
-        )]
-        pub output_format_serialization_options: ::core::option::Option<
-            table_read_options::OutputFormatSerializationOptions,
-        >,
+        #[prost(oneof = "table_read_options::OutputFormatSerializationOptions", tags = "3, 4")]
+        pub output_format_serialization_options:
+            ::core::option::Option<table_read_options::OutputFormatSerializationOptions>,
     }
     /// Nested message and enum types in `TableReadOptions`.
     pub mod table_read_options {
@@ -556,17 +518,7 @@ pub mod read_session {
         /// creating a read session requesting Arrow responses, setting both native
         /// Arrow compression and application-level response compression will not be
         /// allowed - choose, at most, one kind of compression.
-        #[derive(
-            Clone,
-            Copy,
-            Debug,
-            PartialEq,
-            Eq,
-            Hash,
-            PartialOrd,
-            Ord,
-            ::prost::Enumeration
-        )]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
         #[repr(i32)]
         pub enum ResponseCompressionCodec {
             /// Default is no compression.
@@ -665,17 +617,7 @@ pub struct WriteStream {
 /// Nested message and enum types in `WriteStream`.
 pub mod write_stream {
     /// Type enum of the stream.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Type {
         /// Unknown type.
@@ -713,17 +655,7 @@ pub mod write_stream {
         }
     }
     /// Mode enum of the stream.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum WriteMode {
         /// Unknown type.
@@ -1094,10 +1026,7 @@ pub struct AppendRowsRequest {
         map = "string, enumeration(append_rows_request::MissingValueInterpretation)",
         tag = "7"
     )]
-    pub missing_value_interpretations: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        i32,
-    >,
+    pub missing_value_interpretations: ::std::collections::HashMap<::prost::alloc::string::String, i32>,
     /// Optional. Default missing value interpretation for all columns in the
     /// table. When a value is specified on an `AppendRowsRequest`, it is applied
     /// to all requests on the connection from that point forward, until a
@@ -1142,17 +1071,7 @@ pub mod append_rows_request {
     /// An enum to indicate how to interpret missing values of fields that are
     /// present in user schema but missing in rows. A missing value can represent a
     /// NULL or a column default value defined in BigQuery table schema.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum MissingValueInterpretation {
         /// Invalid missing value interpretation. Requests with this value will be
@@ -1347,17 +1266,7 @@ pub struct StorageError {
 /// Nested message and enum types in `StorageError`.
 pub mod storage_error {
     /// Error code for `StorageError`.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum StorageErrorCode {
         /// Default error.
@@ -1460,17 +1369,7 @@ pub struct RowError {
 /// Nested message and enum types in `RowError`.
 pub mod row_error {
     /// Error code for `RowError`.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum RowErrorCode {
         /// Default error.
@@ -1506,10 +1405,10 @@ pub mod big_query_read_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// BigQuery Read API.
     ///
     /// The Read API can be used to read data from BigQuery.
@@ -1543,22 +1442,16 @@ pub mod big_query_read_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> BigQueryReadClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> BigQueryReadClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::Body>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             BigQueryReadClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1619,23 +1512,16 @@ pub mod big_query_read_client {
             self.inner
                 .ready()
                 .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.bigquery.storage.v1.BigQueryRead/CreateReadSession",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.bigquery.storage.v1.BigQueryRead",
-                        "CreateReadSession",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryRead",
+                "CreateReadSession",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Reads rows from the stream in the format prescribed by the ReadSession.
@@ -1648,30 +1534,19 @@ pub mod big_query_read_client {
         pub async fn read_rows(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadRowsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::ReadRowsResponse>>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<super::ReadRowsResponse>>, tonic::Status>
+        {
             self.inner
                 .ready()
                 .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
             let codec = tonic_prost::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.cloud.bigquery.storage.v1.BigQueryRead/ReadRows",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.cloud.bigquery.storage.v1.BigQueryRead/ReadRows");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.bigquery.storage.v1.BigQueryRead",
-                        "ReadRows",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryRead",
+                "ReadRows",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         /// Splits a given `ReadStream` into two `ReadStream` objects. These
@@ -1689,30 +1564,19 @@ pub mod big_query_read_client {
         pub async fn split_read_stream(
             &mut self,
             request: impl tonic::IntoRequest<super::SplitReadStreamRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::SplitReadStreamResponse>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<super::SplitReadStreamResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
             let codec = tonic_prost::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.cloud.bigquery.storage.v1.BigQueryRead/SplitReadStream",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.cloud.bigquery.storage.v1.BigQueryRead/SplitReadStream");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.bigquery.storage.v1.BigQueryRead",
-                        "SplitReadStream",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryRead",
+                "SplitReadStream",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1724,10 +1588,10 @@ pub mod big_query_write_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// BigQuery Write API.
     ///
     /// The Write API can be used to write data to BigQuery.
@@ -1764,22 +1628,16 @@ pub mod big_query_write_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> BigQueryWriteClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> BigQueryWriteClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::Body>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             BigQueryWriteClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1827,23 +1685,16 @@ pub mod big_query_write_client {
             self.inner
                 .ready()
                 .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.bigquery.storage.v1.BigQueryWrite/CreateWriteStream",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.bigquery.storage.v1.BigQueryWrite",
-                        "CreateWriteStream",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryWrite",
+                "CreateWriteStream",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Appends data to the given stream.
@@ -1880,30 +1731,20 @@ pub mod big_query_write_client {
         pub async fn append_rows(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = super::AppendRowsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::AppendRowsResponse>>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<super::AppendRowsResponse>>, tonic::Status>
+        {
             self.inner
                 .ready()
                 .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
             let codec = tonic_prost::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.cloud.bigquery.storage.v1.BigQueryWrite/AppendRows",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.cloud.bigquery.storage.v1.BigQueryWrite/AppendRows");
             let mut req = request.into_streaming_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.bigquery.storage.v1.BigQueryWrite",
-                        "AppendRows",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryWrite",
+                "AppendRows",
+            ));
             self.inner.streaming(req, path, codec).await
         }
         /// Gets information about a write stream.
@@ -1914,23 +1755,15 @@ pub mod big_query_write_client {
             self.inner
                 .ready()
                 .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
             let codec = tonic_prost::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.cloud.bigquery.storage.v1.BigQueryWrite/GetWriteStream",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.cloud.bigquery.storage.v1.BigQueryWrite/GetWriteStream");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.bigquery.storage.v1.BigQueryWrite",
-                        "GetWriteStream",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryWrite",
+                "GetWriteStream",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Finalize a write stream so that no new data can be appended to the
@@ -1938,30 +1771,20 @@ pub mod big_query_write_client {
         pub async fn finalize_write_stream(
             &mut self,
             request: impl tonic::IntoRequest<super::FinalizeWriteStreamRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FinalizeWriteStreamResponse>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<super::FinalizeWriteStreamResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.bigquery.storage.v1.BigQueryWrite/FinalizeWriteStream",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.bigquery.storage.v1.BigQueryWrite",
-                        "FinalizeWriteStream",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryWrite",
+                "FinalizeWriteStream",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Atomically commits a group of `PENDING` streams that belong to the same
@@ -1973,30 +1796,20 @@ pub mod big_query_write_client {
         pub async fn batch_commit_write_streams(
             &mut self,
             request: impl tonic::IntoRequest<super::BatchCommitWriteStreamsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::BatchCommitWriteStreamsResponse>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<super::BatchCommitWriteStreamsResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.cloud.bigquery.storage.v1.BigQueryWrite/BatchCommitWriteStreams",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.bigquery.storage.v1.BigQueryWrite",
-                        "BatchCommitWriteStreams",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryWrite",
+                "BatchCommitWriteStreams",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Flushes rows to a BUFFERED stream.
@@ -2010,30 +1823,19 @@ pub mod big_query_write_client {
         pub async fn flush_rows(
             &mut self,
             request: impl tonic::IntoRequest<super::FlushRowsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::FlushRowsResponse>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<super::FlushRowsResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
             let codec = tonic_prost::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.cloud.bigquery.storage.v1.BigQueryWrite/FlushRows",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.cloud.bigquery.storage.v1.BigQueryWrite/FlushRows");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "google.cloud.bigquery.storage.v1.BigQueryWrite",
-                        "FlushRows",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryWrite",
+                "FlushRows",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }

--- a/src/job.rs
+++ b/src/job.rs
@@ -621,9 +621,9 @@ mod test {
             .insert_all(project_id, dataset_id, table_id, insert_request)
             .await;
 
-        assert!(result.is_ok(), "{:?}", result);
+        assert!(result.is_ok(), "{result:?}");
         let result = result.unwrap();
-        assert!(result.insert_errors.is_none(), "{:?}", result);
+        assert!(result.insert_errors.is_none(), "{result:?}");
 
         // Query
         let query_response = client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub struct Client {
 }
 
 impl Client {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         dataset_api: DatasetApi,
         table_api: TableApi,

--- a/src/model/query_response.rs
+++ b/src/model/query_response.rs
@@ -71,66 +71,75 @@ pub struct ResultSet {
     fields: HashMap<String, usize>,
 }
 
+impl Default for ResultSet {
+    fn default() -> Self {
+        Self {
+            cursor: -1,
+            row_count: 0,
+            rows: Vec::new(),
+            fields: HashMap::new(),
+        }
+    }
+}
+
 impl ResultSet {
     pub fn new_from_query_response(query_response: QueryResponse) -> Self {
-        if query_response.job_complete.unwrap_or(false) && query_response.schema.is_some() {
-            // rows and tables schema are only present for successfully completed jobs.
-            let row_count = query_response.rows.as_ref().map_or(0, Vec::len) as i64;
-            let table_schema = query_response.schema.as_ref().expect("Expecting a schema");
-            let table_fields = table_schema
-                .fields
-                .as_ref()
-                .expect("Expecting a non empty list of fields");
-            let fields: HashMap<String, usize> = table_fields
-                .iter()
-                .enumerate()
-                .map(|(pos, field)| (field.name.clone(), pos))
-                .collect();
-            let rows = query_response.rows.unwrap_or_default();
-            Self {
-                cursor: -1,
-                row_count,
-                rows,
-                fields,
-            }
-        } else {
-            Self {
-                cursor: -1,
-                row_count: 0,
-                rows: vec![],
-                fields: HashMap::new(),
-            }
+        if !query_response.job_complete.unwrap_or(false) {
+            return Self::default();
+        }
+
+        let Some(table_schema) = query_response.schema.as_ref() else {
+            return Self::default();
+        };
+
+        // Rows and tables schema are only present for successfully completed jobs.
+        let row_count = query_response.rows.as_ref().map_or(0, Vec::len) as i64;
+        let table_fields = table_schema
+            .fields
+            .as_ref()
+            .expect("Expecting a non empty list of fields");
+        let fields: HashMap<String, usize> = table_fields
+            .iter()
+            .enumerate()
+            .map(|(pos, field)| (field.name.clone(), pos))
+            .collect();
+        let rows = query_response.rows.unwrap_or_default();
+
+        Self {
+            cursor: -1,
+            row_count,
+            rows,
+            fields,
         }
     }
 
     pub fn new_from_get_query_results_response(get_query_results_response: GetQueryResultsResponse) -> Self {
-        if get_query_results_response.job_complete.unwrap_or(false) && get_query_results_response.schema.is_some() {
-            // rows and tables schema are only present for successfully completed jobs.
-            let row_count = get_query_results_response.rows.as_ref().map_or(0, Vec::len) as i64;
-            let table_schema = get_query_results_response.schema.as_ref().expect("Expecting a schema");
-            let table_fields = table_schema
-                .fields
-                .as_ref()
-                .expect("Expecting a non empty list of fields");
-            let fields: HashMap<String, usize> = table_fields
-                .iter()
-                .enumerate()
-                .map(|(pos, field)| (field.name.clone(), pos))
-                .collect();
-            let rows = get_query_results_response.rows.unwrap_or_default();
-            Self {
-                cursor: -1,
-                row_count,
-                rows,
-                fields,
-            }
-        } else {
-            Self {
-                cursor: -1,
-                row_count: 0,
-                rows: vec![],
-                fields: HashMap::new(),
-            }
+        if !get_query_results_response.job_complete.unwrap_or(false) {
+            return Self::default();
+        }
+
+        let Some(table_schema) = get_query_results_response.schema.as_ref() else {
+            return Self::default();
+        };
+
+        // Rows and tables schema are only present for successfully completed jobs.
+        let row_count = get_query_results_response.rows.as_ref().map_or(0, Vec::len) as i64;
+        let table_fields = table_schema
+            .fields
+            .as_ref()
+            .expect("Expecting a non empty list of fields");
+        let fields: HashMap<String, usize> = table_fields
+            .iter()
+            .enumerate()
+            .map(|(pos, field)| (field.name.clone(), pos))
+            .collect();
+        let rows = get_query_results_response.rows.unwrap_or_default();
+
+        Self {
+            cursor: -1,
+            row_count,
+            rows,
+            fields,
         }
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1120,11 +1120,7 @@ pub mod test {
             vec![create_test_actor(5, "Charlie"), create_test_actor(6, "Dave")],
         );
 
-        let batch3 = TableBatch::new(
-            stream_name,
-            table_descriptor,
-            vec![create_test_actor(7, "Eve")],
-        );
+        let batch3 = TableBatch::new(stream_name, table_descriptor, vec![create_test_actor(7, "Eve")]);
 
         let table_batches = vec![batch1, batch2, batch3];
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -31,7 +31,7 @@ use tonic::{
     transport::{Channel, ClientTlsConfig},
     Request, Status, Streaming,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use crate::google::cloud::bigquery::storage::v1::{GetWriteStreamRequest, ProtoRows, WriteStream, WriteStreamView};
 use crate::{
@@ -112,15 +112,6 @@ pub struct StorageApiConfig {
     pub max_inflight_requests: usize,
 }
 
-impl Default for StorageApiConfig {
-    fn default() -> Self {
-        Self {
-            pool_size: DEFAULT_POOL_SIZE,
-            max_inflight_requests: DEFAULT_POOL_SIZE * DEFAULT_REQUESTS_PER_CONNECTION,
-        }
-    }
-}
-
 impl StorageApiConfig {
     /// Creates a new configuration with the specified pool size.
     pub fn with_pool_size(mut self, pool_size: usize) -> Self {
@@ -132,6 +123,15 @@ impl StorageApiConfig {
     pub fn with_max_inflight_requests(mut self, max_inflight_requests: usize) -> Self {
         self.max_inflight_requests = max_inflight_requests;
         self
+    }
+}
+
+impl Default for StorageApiConfig {
+    fn default() -> Self {
+        Self {
+            pool_size: DEFAULT_POOL_SIZE,
+            max_inflight_requests: DEFAULT_POOL_SIZE * DEFAULT_REQUESTS_PER_CONNECTION,
+        }
     }
 }
 
@@ -1271,7 +1271,7 @@ pub mod test {
 
             // Verify each individual response for detailed error reporting.
             for response in &batch_result.responses {
-                assert!(response.is_ok(), "Response should be successful: {:?}", response);
+                assert!(response.is_ok(), "Response should be successful: {response:?}");
             }
 
             // Verify that some bytes were sent (should be greater than 0).

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -444,8 +444,14 @@ struct TableBatchInner<M> {
 /// enabling efficient batch operations and optimal parallelism distribution
 /// across multiple tables in concurrent append operations. Cloning is cheap
 /// as the data is stored behind an [`Arc`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TableBatch<M>(Arc<TableBatchInner<M>>);
+
+impl<M> Clone for TableBatch<M> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 impl<M> TableBatch<M> {
     /// Creates a new table batch targeting the specified stream.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -138,7 +138,7 @@ impl ConnectionPool {
             // through connections in the pool.
             .queue_mode(QueueMode::Fifo)
             .build()
-            .map_err(|e| BQError::ConnectionPoolError(format!("Failed to create connection pool: {}", e)))?;
+            .map_err(|e| BQError::ConnectionPoolError(format!("Failed to create connection pool: {e}")))?;
 
         Ok(Self { pool })
     }
@@ -151,7 +151,7 @@ impl ConnectionPool {
         self.pool
             .get()
             .await
-            .map_err(|e| BQError::ConnectionPoolError(format!("Failed to get connection from pool: {}", e)))
+            .map_err(|e| BQError::ConnectionPoolError(format!("Failed to get connection from pool: {e}")))
     }
 }
 
@@ -738,7 +738,7 @@ impl StorageApi {
                             }
                         }
                         Err(pool_err) => {
-                            batch_responses.push(Err(Status::unknown(format!("Pool error: {}", pool_err))));
+                            batch_responses.push(Err(Status::unknown(format!("Pool error: {pool_err}"))));
                         }
                     },
                     Err(err) => {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -263,7 +263,7 @@ pub struct TableDescriptor {
 #[derive(Debug)]
 pub struct TableBatch<M> {
     /// Target stream identifier for the append operations.
-    pub stream_name: StreamName,
+    pub stream_name: Arc<StreamName>,
     /// Schema descriptor for the target table.
     pub table_descriptor: Arc<TableDescriptor>,
     /// Collection of rows to be appended to the table.
@@ -275,7 +275,7 @@ impl<M> TableBatch<M> {
     ///
     /// Combines rows with their destination metadata to form a complete
     /// batch ready for processing by append operations.
-    pub fn new(stream_name: StreamName, table_descriptor: Arc<TableDescriptor>, rows: Arc<[M]>) -> Self {
+    pub fn new(stream_name: Arc<StreamName>, table_descriptor: Arc<TableDescriptor>, rows: Arc<[M]>) -> Self {
         Self {
             stream_name,
             table_descriptor,
@@ -407,7 +407,7 @@ pub struct AppendRequestsStream<M> {
     /// Protobuf schema definition for the target table.
     proto_schema: ProtoSchema,
     /// Target stream identifier for the append operations.
-    stream_name: StreamName,
+    stream_name: Arc<StreamName>,
     /// Unique identifier for tracing and debugging requests.
     trace_id: String,
     /// Current position in the batch being processed.
@@ -430,7 +430,7 @@ impl<M> AppendRequestsStream<M> {
     fn new(
         batch: Arc<[M]>,
         proto_schema: ProtoSchema,
-        stream_name: StreamName,
+        stream_name: Arc<StreamName>,
         trace_id: String,
         bytes_sent_counter: Arc<AtomicUsize>,
     ) -> Self {
@@ -1075,7 +1075,7 @@ pub mod test {
             .unwrap();
 
         let table_descriptor = create_test_table_descriptor();
-        let stream_name = StreamName::new_default(project_id.clone(), dataset_id.clone(), table_id.clone());
+        let stream_name = Arc::new(StreamName::new_default(project_id.clone(), dataset_id.clone(), table_id.clone()));
         let trace_id = "test_table_batches";
 
         // Create multiple table batches (all targeting the same table in this test)

--- a/src/tabledata.rs
+++ b/src/tabledata.rs
@@ -246,7 +246,7 @@ mod test {
             .tabledata()
             .insert_all(project_id, dataset_id, table_id, insert_request)
             .await;
-        assert!(result.is_ok(), "Error: {:?}", result);
+        assert!(result.is_ok(), "Error: {result:?}");
 
         #[cfg(feature = "gzip")]
         {
@@ -267,7 +267,7 @@ mod test {
                 .tabledata()
                 .insert_all_gzipped(project_id, dataset_id, table_id, insert_request_gzipped)
                 .await;
-            assert!(result_gzipped.is_ok(), "Error: {:?}", result_gzipped);
+            assert!(result_gzipped.is_ok(), "Error: {result_gzipped:?}");
         }
 
         // Remove table and dataset


### PR DESCRIPTION
## Overview

This PR enhances the storage write API and connection management to better support retry scenarios and DDL changes in BigQuery.

## Changes

### API Enhancement: Clonable `TableBatch`

Reworks the append method to accept a clonable `TableBatch`, enabling efficient retries without redundant copies. Previously, retry loops required copying batches on each attempt; now batches can be sent multiple times by cloning the reference rather than duplicating the underlying data.

### Connection Pooling Improvements

**Connection invalidation**: Introduces a mechanism to invalidate all active connections. This is essential for BigQuery, which requires fresh connections after DDL changes (schema modifications, table alterations) to ensure subsequent writes operate against the updated schema. The invalidation guarantees that after the invalidation method call, all connections handed out will be "new" in the sense that they are created after that method call.

### Simplified Configuration

Adds a new Storage Write API configuration that enforces connection pool limits and max inflight request constraints globally across method calls. This eliminates the need for callers to manually coordinate these limits, simplifying API usage and preventing resource exhaustion.